### PR TITLE
Create share-experiences.html

### DIFF
--- a/platform-html-code/share-experiences.html
+++ b/platform-html-code/share-experiences.html
@@ -1,0 +1,89 @@
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="more-detail">
+      Share your story:
+    </label>
+  </h1>
+  <div id="more-detail-hint" class="govuk-hint">
+    Type in the box below to share a time or a place your senses have affected you:
+  </div>
+  <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
+</div>
+<div class="govuk-form-group">
+  <button class="govuk-button" data-module="govuk-button">
+Save
+</button>
+<button class="govuk-button" data-module="govuk-button">
+Submit
+</button>
+  <fieldset class="govuk-fieldset" aria-describedby="permissions">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        Who would you like to share your story with?
+      </h1>
+    </legend>
+    <div id="permissions" class="govuk-hint">
+      Select all that apply.
+    </div>
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="research" name="researchers" type="checkbox" value="researchers">
+        <label class="govuk-label govuk-checkboxes__label" for="researchers">
+          Share with researchers
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="public" name="public" type="checkbox" value="publicly">
+        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+          Share publicly on AutSPACEs
+        </label>
+      </div
+    </div>
+    <button class="govuk-button" data-module="govuk-button">
+
+  </fieldset>
+</div>
+
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="more-detail">
+      What would help?
+    </label>
+  </h1>
+  <div id="more-detail-hint" class="govuk-hint">
+    Type in the box below to share solutions or suggestions for what would have made your experience better.
+  </div>
+  <div id="more-detail-hint" class="govuk-hint">
+    If you do not wish to answer this question leave this box blank. Your story will still be shared.
+  </div>
+  <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
+</div>
+<div class="govuk-form-group">
+  <button class="govuk-button" data-module="govuk-button">
+Save
+</button>
+<button class="govuk-button" data-module="govuk-button">
+Submit
+</button>
+  <fieldset class="govuk-fieldset" aria-describedby="permissions">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+      <h1 class="govuk-fieldset__heading">
+        Who would you like to share your ideas with?
+      </h1>
+    </legend>
+    <div id="permissions" class="govuk-hint">
+      Select all that apply.
+    </div>
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="research" name="researchers" type="checkbox" value="researchers">
+        <label class="govuk-label govuk-checkboxes__label" for="researchers">
+          Share with researchers
+        </label>
+      </div>
+      <div class="govuk-checkboxes__item">
+        <input class="govuk-checkboxes__input" id="public" name="public" type="checkbox" value="publicly">
+        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+          Share publicly on AutSPACEs
+        </label>
+      </div
+    </div>
+


### PR DESCRIPTION
# Summary

This PR adds a folder to hold html code for each page of the AutSPACEs platform, and creates a **very basic** MVP version of the "share experience" page with no styling. 

# Details

The MVP has the following features:

Add question prompts for experiences and solutions
Take text input
Give sharing options (with researchers and publicly, both or neither)
Save button
Submit button

The code is created by putting together a series of components provided by [gov.uk](https://www.gov.uk/).
These are available under the Open Government Licence v3.0, meaning they can be used, and shoud also be accredited. 

# Still to add for MVP 

* Navigation bar
* Connections to other pages
* OH backend integration
* Outputs taken from user inputs in view own experiences, moderation, and view other's experiences pages

# Tested?

Very basic testing using a [real-time html renderer](https://htmledit.squarefree.com/)

