### PR TITLE
Create are-you-autistic.html

### DIFF
--- a/platform-html-code/sign-up-flow/are-you-autistic.html
+++ b/platform-html-code/sign-up-flow/are-you-autistic.html
@@ -1,0 +1,63 @@
+<div class="govuk-width-container">
+  <a href="#" class="govuk-back-link">Back</a>
+
+  <main class="govuk-main-wrapper " id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <form action="/form-handler" method="post" novalidate>
+
+          <div class="govuk-form-group">
+            <fieldset class="govuk-fieldset">
+              <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                  Are you autistic?
+                </h1>
+              </legend>
+              <div class="govuk-radios">
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="are-you-autistic" name="are-you-autistic" type="radio" value="Yes">
+                  <label class="govuk-label govuk-radios__label" for="are-you-autistic">
+                    Yes
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="are-you-autistic-2" name="are-you-autistic" type="radio" value="No">
+                  <label class="govuk-label govuk-radios__label" for="are-you-autistic-2">
+                    No
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="are-you-autistic-3" name="are-you-autistic" type="radio" value="Unsure">
+                  <label class="govuk-label govuk-radios__label" for="are-you-autistic-3">
+                    Unsure
+                  </label>
+                </div>
+                <div class="govuk-radios__item">
+                  <input class="govuk-radios__input" id="are-you-autistic-4" name="are-you-autistic" type="radio" value="prefer-not-to-say">
+                  <label class="govuk-label govuk-radios__label" for="are-you-autistic-4">
+                    Prefer not to say
+                  </label>
+                </div>
+<div class="govuk-form-group">
+  <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="self-describe">
+      I prefer to self describe
+    </label>
+  </h1>
+  <div id="event-name-hint" class="govuk-hint">
+    Please type your preferred description in the box below:
+  </div>
+  <input class="govuk-input" id="event-name" name="event-name" type="text" aria-describedby="self-describe-hint">
+</div>
+              </div>
+
+            </fieldset>
+          </div>
+
+          <button class="govuk-button" data-module="govuk-button">
+            Submit
+          </button>
+        </form>
+      </div>
+    </div>
+  </main>
+</div>


### PR DESCRIPTION
## Summary

This PR adds a folder to hold html code for each page of the AutSPACEs sign-up flow, and creates a very basic page taking user's autism status with no styling.

## Details

The MVP has the following features:

Add question with radio button responses
Take text input for those who want to self-describe
Submit button

The code is created by putting together a series of components provided by gov.uk.
These are available under the Open Government Licence v3.0, meaning they can be used, and shoud also be accredited.

## Still to add for MVP

     * Allow user to create username and password to sign-in to platform
     * Must use Open Humans sign in process: see diagram in the user-flow doc
     * confirmation and forward-navigation

## Tested?

Very basic testing using a real-time html renderer