### PR TITLE
Create share-experiences.html

### DIFF
--- a/platform-html-code/share-experiences.html
+++ b/platform-html-code/share-experiences.html
@@ -33,7 +33,7 @@ Submit
       </div>
       <div class="govuk-checkboxes__item">
         <input class="govuk-checkboxes__input" id="public" name="public" type="checkbox" value="publicly">
-        <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+        <label class="govuk-label govuk-checkboxes__label" for="researchers">
           Share publicly on AutSPACEs
         </label>
       </div


### PR DESCRIPTION
# Summary

This PR adds a folder to hold html code for each page of the AutSPACEs platform, and creates a **very basic** MVP version of the "share experience" page with no styling. 

# Details

The MVP has the following features:

Add question prompts for experiences and solutions
Take text input
Give sharing options (with researchers and publicly, both or neither)
Save button
Submit button

The code is created by putting together a series of components provided by [gov.uk](https://www.gov.uk/).
These are available under the Open Government Licence v3.0, meaning they can be used, and shoud also be accredited. 

# Still to add for MVP 

* Navigation bar
* Connections to other pages
* OH backend integration
* Outputs taken from user inputs in view own experiences, moderation, and view other's experiences pages

# Tested?

Very basic testing using a [real-time html renderer](https://htmledit.squarefree.com/)

