### PR TITLE
fix: Replace sh with bash in entrypoint

### DIFF
--- a/docker/django/entrypoint.sh
+++ b/docker/django/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 set -o errexit
 set -o nounset

--- a/docs/pages/template/troubleshooting.rst
+++ b/docs/pages/template/troubleshooting.rst
@@ -60,7 +60,7 @@ Django is saying that it cannot find a matching URL pattern for the URL you've p
 Styling is All Wrong!
 ---------------------
 This is because the CSP settings within the project are quite strict. The css, scripts, and other static assets used to make the website look pretty isn't allowed for security reasons. You can see these errors when opening up the `Inspector` (Right Click -> Inspect Element) and viewing the Console tab within your browser of choice. See the following for more information.
-`Django CSP <https://django-csp.readthedocs.io/en/latest/configuration.htm://django-csp.readthedocs.io/en/latest/configuration.html>`_
-`Unsafe-Inline <https://content-security-policy.com/unsafe-inline/>`_
-`Managing Static Files <https://docs.djangoproject.com/en/2.2/howto/static-files/>`_
+- `Django CSP <https://django-csp.readthedocs.io/en/latest/configuration.htm://django-csp.readthedocs.io/en/latest/configuration.html>`_
+- `Unsafe-Inline <https://content-security-policy.com/unsafe-inline/>`_
+- `Managing Static Files <https://docs.djangoproject.com/en/2.2/howto/static-files/>`_
 

--- a/docs/pages/template/troubleshooting.rst
+++ b/docs/pages/template/troubleshooting.rst
@@ -55,12 +55,12 @@ Django Problems
 
 NoReverseMatch Errors
 ---------------------
-Django is saying that it cannot find a matching URL pattern for the URL you've provided in any of your installed app's urls. (i.e. urls.py, views.py, etc.) See (here)[https://stackoverflow.com/questions/38390177/what-is-a-noreversematch-error-and-how-do-i-fix-it] for more information.
+Django is saying that it cannot find a matching URL pattern for the URL you've provided in any of your installed app's urls. (i.e. urls.py, views.py, etc.) See `here <https://stackoverflow.com/questions/38390177/what-is-a-noreversematch-error-and-how-do-i-fix-it>`_ for more information.
 
 Styling is All Wrong!
 ---------------------
 This is because the CSP settings within the project are quite strict. The css, scripts, and other static assets used to make the website look pretty isn't allowed for security reasons. You can see these errors when opening up the `Inspector` (Right Click -> Inspect Element) and viewing the Console tab within your browser of choice. See the following for more information.
-(Django CSP)[https://django-csp.readthedocs.io/en/latest/configuration.htm://django-csp.readthedocs.io/en/latest/configuration.html]
-(Unsafe-Inline)[https://content-security-policy.com/unsafe-inline/]
-(Managing Static Files)[https://docs.djangoproject.com/en/2.2/howto/static-files/]
+`Django CSP <https://django-csp.readthedocs.io/en/latest/configuration.htm://django-csp.readthedocs.io/en/latest/configuration.html>`_
+`Unsafe-Inline <https://content-security-policy.com/unsafe-inline/>`_
+`Managing Static Files <https://docs.djangoproject.com/en/2.2/howto/static-files/>`_
 


### PR DESCRIPTION
## Description
When running docker in a Windows environment, given that the user is using VSCode as the IDE and installed Desktop Git and Desktop Docker, executing `./docker-run.sh` fails with the following error message. 

`/usr/bin/env sh Permission denied`

## Definition of Done
- [x] Apply fix
- [ ] Add problem and solution to troubleshooting doc. 

## The Fix
Use `bash`, which is globally available, instead of `/usr/bin/env sh`, which has issues with execution. 

### Additionals
If this above doesn't work, here are a few additional steps to attempt. 

1. Within VSCode, ensure the end of the line sequence is set to `LF` not `CRLF`
![CleanShot 2021-11-02 at 07 55 57](https://user-images.githubusercontent.com/1872836/139841788-6cc5db49-5826-42a4-b38f-a675eeffdccb.jpg)
2. Add the path to `C:\Program/ Files\Git\bin\` to the `PATH` environment variable.
3. Verify that Docker is running. 