### PR TITLE
Add instruction for M1 processors to dev readme

### DIFF
--- a/dev_readme.md
+++ b/dev_readme.md
@@ -70,8 +70,8 @@ The project builds and runs in a self-contained environment called Docker. This 
 1. Open up Terminal or Command Line in the root level of the repository and execute the following command: `./docker-run.sh`
 
    If this step fails with the following error
-   ```qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
-   ```
+   ```qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory```
+   
    You may have an M1 chip in your computer. Try again after setting your local `DOCKER_DEFAULT_PLATFORM` to linux/amd64
    ```export DOCKER_DEFAULT_PLATFORM=linux/amd64```
 

--- a/dev_readme.md
+++ b/dev_readme.md
@@ -72,7 +72,7 @@ The project builds and runs in a self-contained environment called Docker. This 
    If this step fails with the following error
    ```qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
    ```
-   You may have an M1 chip in your cimputer. Try again after setting your local `DOCKER_DEFAULT_PLATFORM` to linux/amd64
+   You may have an M1 chip in your computer. Try again after setting your local `DOCKER_DEFAULT_PLATFORM` to linux/amd64
    ```export DOCKER_DEFAULT_PLATFORM=linux/amd64```
 
 2. Open your browser to `http://localhost:8000`

--- a/dev_readme.md
+++ b/dev_readme.md
@@ -68,6 +68,13 @@ OPENHUMANS_APP_BASE_URL="http://localhost:8000"
 The project builds and runs in a self-contained environment called Docker. This means developer environments are preserved, and you don't need to mess with any dependency management or installation.
 
 1. Open up Terminal or Command Line in the root level of the repository and execute the following command: `./docker-run.sh`
+
+   If this step fails with the following error
+   ```qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
+   ```
+   You may have an M1 chip in your cimputer. Try again after setting your local `DOCKER_DEFAULT_PLATFORM` to linux/amd64
+   ```export DOCKER_DEFAULT_PLATFORM=linux/amd64```
+
 2. Open your browser to `http://localhost:8000`
 
 *This will display the AutSPACEs website.* Yay!


### PR DESCRIPTION
Some contributors have been unable to build on amd64 machines. This fixed the issue in my case, hopefully it works for everyone else too.