### PR TITLE
Refactor upload for easier subsequent use of data

### DIFF
--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -90,6 +90,7 @@ def upload(data, ohmember):
     metadata = {
         'uuid': str(uuid.uuid1()),   
         'description':'placeholder',
+        'tags': make_tags(data),
         **output_json,
         }
     
@@ -111,6 +112,22 @@ def upload(data, ohmember):
             open_humans_member=ohmember,
             experience_id=metadata['uuid'])
 
+def make_tags(data):
+    """builds list of tags based on data"""
+    
+    tag_map = {'viewable': {'True':'public',
+                            'False':'not public'},
+               'research': {'True':'research',
+                            'False':'non-research'}}
+    
+    # TODO: do we want to add tags for the triggering checkboxes herte?
+    
+    tags = [tag_map[k].get(str(v)) 
+            for k,v in data.items() 
+            if k in tag_map.keys()]
+    
+    return tags
+    
     
 
 def list_files(request):

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -56,7 +56,10 @@ def share_experience(request, edit=False):
         if form.is_valid():
             # process the data in form.cleaned_data as required
             if not edit:
-                upload(form.cleaned_data, request.user.openhumansmember)
+                # here we need to catch whether the form is an 'edited' experience.
+                # a potential way of doing this is have a hidden form field 'experience_id', and, if that is populated (which we would make sure of when editing), delete a file.
+                
+                upload(form.cleaned_data, request.user.openhumansmember)                
                 # redirect to a new URL:
                 return redirect('main:confirm_page')
 
@@ -78,45 +81,36 @@ def upload(data, ohmember):
         data (dict): an experience
         ohmember : request.user.openhumansmember
     """
-    experience_text = data.get('experience')
-    wish_different_text = data.get('wish_different')
-    title_text = data.get('title')
-    viewable = data.get('viewable')
-    if not viewable:
-        viewable = 'not public'
-    research = data.get('research')
-    if not research:
-        research = 'non-research'
-    if experience_text:
-        experience_id = str(uuid.uuid1())
-        output_json = {
-            'text': experience_text,
-            'wish_different': wish_different_text,
-            'title': title_text,
-            'timestamp': str(datetime.datetime.now())}
-        output = io.StringIO()
-        output.write(json.dumps(output_json))
-        output.seek(0)
-        metadata = {
-            'uuid': experience_id,
-            'tags': [viewable, research],        
-            'description':'placeholder',
-            **output_json,
-            }
-            
-        ohmember.upload(
-            stream=output,
-            filename='testfile.json',
-            metadata=metadata)
-        
-        if viewable == 'viewable':
-            PublicExperience.objects.create(
-                experience_text=experience_text,
-                difference_text=wish_different_text,
-                title_text=title_text,
-                open_humans_member=ohmember,
-                experience_id=experience_id)
     
+    output_json = {
+            'data': data,
+            'timestamp': str(datetime.datetime.now())}
+    
+    # by saving the output json into metadata we can access the fields easily through request.user.openhumansmember.list_files().
+    metadata = {
+        'uuid': str(uuid.uuid1()),   
+        'description':'placeholder',
+        **output_json,
+        }
+    
+    # create stream for oh upload
+    output = io.StringIO()
+    output.write(json.dumps(output_json))
+    output.seek(0)
+            
+    ohmember.upload(
+        stream=output,
+        filename='testfile.json',
+        metadata=metadata)
+        
+    if data['viewable']:
+        PublicExperience.objects.create(
+            experience_text=data['experience'],
+            difference_text=data['wish_different'],
+            title_text=data['title'],
+            open_humans_member=ohmember,
+            experience_id=metadata['uuid'])
+
     
 
 def list_files(request):


### PR DESCRIPTION
The following changes were made: 

- `'data'` is now a key in the output, and in the metadata. `data` contains all the fields in the form, as they are specified in `ShareExperienceForm`. This will make it easy to deal with the files in `my_stories`, since I believe you can simply instantiate the form using `form = ShareExperienceForm(file.metadata.data)`. 
- also separated the tags creation to make it more modular. We may or may not want to use the `tags` field (afaik this is so that OH recognises the tags), since we have all the information we need in a dictionary in `metadata.data`. 


@helendduncan this impacts how you will edit `my_stories.html`. I suggest you merge into `frontend_testing` if you are happy, then rebase your branch to `frontend_testing`.  