### PR TITLE
correct passing of data to share_experience

### DIFF
--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -111,7 +111,7 @@
       {% for file in files %}
       <tr>
         <th scope="row">{{ forloop.counter }}</th>
-        <td>{% firstof file.metadata.title "notitle" %}</td>
+        <td>{% firstof file.metadata.data.title "notitle" %}</td>
         <td>{% firstof file.created "Creation date unknown" %}</td>
         <td>
           {% for tag in file.metadata.tags %}
@@ -133,7 +133,10 @@
       </td>
       <td>
         <form action="{% url 'main:share_exp' True%}" method="post">{% csrf_token %}
-          <input type="text" name="file" value={{ file }}  style="display:none"/>
+          <input type="hidden" name="file_id" value={{ file.id }}/>
+          {% for key, val in file.metadata.data.items %}
+            <input type="hidden" name={{key}} value="{{val}}" />
+          {% endfor %}
           <button type="submit" class="btn btn-primary">Edit</button>
         </form>
     </td>


### PR DESCRIPTION
This commit successfully passes the necessary form fields to the view `share_experience`, when you click the `Edit` button. 

The `share_experience` view automatically prepopulates the form - this works well.

The next step is to amend the form to have a hidden `file.id` field that we can check for when `edit=False` to determine whether 'this is a form submission of an edited form'.  