### PR TITLE
add other label and left alignment

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -32,9 +32,11 @@ class ShareExperienceForm(forms.Form):
     mentalhealth.group = 2
     negbody = forms.BooleanField(label = 'Negative body image', required=False)
     negbody.group = 2
-    other = forms.CharField(label='',
+    
+    other = forms.CharField(label='Other',
+                            strip=True,
                             max_length=150,
-                            widget=forms.TextInput(attrs={'placeholder':'Other'}), required=False)
+                            widget=forms.TextInput(), required=False)
     other.group = 2
     
     

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -188,8 +188,14 @@
           {% for field in group.list %}
           
             <div class="form-check col-lg-6">
-            {{ field }}    
-            <label for="{{ field.auto_id }}">{{ field.label }}</label>
+              {% if field.label == "Other"%}
+                <label for="{{ field.auto_id }}">{{ field.label }}:</label>
+                {{field}}
+              {% else %}
+                {{ field }}    
+                <label for="{{ field.auto_id }}">{{ field.label }}</label>
+              {% endif %}
+            
             </div>
          
           {% endfor %}


### PR DESCRIPTION
In [this discussion](https://github.com/alan-turing-institute/AutSPACEs/pull/394#discussion_r1045807012) it was suggested to keep a checkbox alongside `Other`, since when you type in `Other` the placeholder disappears.

The simplest solution is to attach an `Other` label, which I have done in this commit. Keeping the checkbox and textbox in sync (e.g. automatic typing enables the checkbox) requires Javascript. Though this is probably simple enough to implement, it would take longer than the few mins dedicated to this solution. I thought it was good enough for now, in order to prioritise other developments towards the MVP.

