### PR TITLE
Remove unnecessary POST request to GET request

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -39,17 +39,12 @@ class ShareExperienceForm(forms.Form):
                             widget=forms.TextInput(), required=False)
     other.group = 2
     
-    
     # sharing options
     viewable = forms.BooleanField(label = "Share on AutSPACE website", required=False)
     viewable.group = 3
     research = forms.BooleanField(label = "Share for research", required=False)
     research.group = 3
-    
-    
-    # hidden field that tracks PublicExperience uuid (which is also the OH filename) when you're editing an experience
-    uuid = forms.CharField(required=False, widget=forms.HiddenInput())
-    uuid.group = "hidden"
+
     # hidden field for moderation status
     moderation_status = forms.BooleanField(widget = forms.HiddenInput(), required=False, initial=False)
     moderation_status.group = "hidden"

--- a/server/apps/main/templates/main/deletion_confirmation.html
+++ b/server/apps/main/templates/main/deletion_confirmation.html
@@ -36,9 +36,7 @@
     
     <div class="row mx-0 py-4 justify-content-start">
       <div class="col-2">
-            <form action="{% url 'main:delete_experience' True %}" method="post">{% csrf_token %}
-              <input type="hidden" name="uuid" value="{{uuid}}"/>
-              <input type="hidden" name="title" value="{{title}}"/>
+            <form action="{% url 'main:delete_exp' uuid title %}" method="post">{% csrf_token %}
               <button type="submit" class="btn btn-danger btn-lg">Yes, Delete</button>
             </form>
       </div>

--- a/server/apps/main/templates/main/deletion_success.html
+++ b/server/apps/main/templates/main/deletion_success.html
@@ -28,7 +28,7 @@
   <div class="confirmation-container">
     <div class="confirm_success">
       <h1 class="big-heading">Success!</h1>
-      <p class="title-text">Experience '{{title}}' does not exist for the current user</p>
+      <p class="title-text">Experience '{{title}}' deleted.</p>
     </div>
  </div>
     <div class="to-do-container">

--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -135,23 +135,18 @@
         {% endfor %}
       </td>
       <td>
-        <form action="{% url 'main:share_exp' True%}" method="post">{% csrf_token %}
-          <input type="hidden" name="uuid" value="{{file.metadata.uuid}}"/>
-          {% for key, val in file.metadata.data.items %}
-            <input type="hidden" name="{{key}}" value="{{val}}"/>
-          {% endfor %}
-          <button type="submit" class="btn btn-primary">Edit</button>
-        </form>
+        <a href="{% url 'main:edit_exp' file.metadata.uuid %}">
+          <button class="btn btn-primary">Edit</button>
+        </a>
     </td>
       <td>
           <a href="{{ file.download_url }}" class="btn btn-secondary btn-sm" target="_blank">Download</a>
       </td>
       <td>
-        <form action="{% url 'main:delete_experience' %}" method="post">{% csrf_token %}
-          <input type="hidden" name="uuid" value="{{file.metadata.uuid}}"/>
-          <input type="hidden" name="title" value="{{file.metadata.data.title}}"/>
-          <button type="submit" class="btn btn-danger">Delete</button>
-        </form>
+        <a href="{% url 'main:delete_exp' file.metadata.uuid %}">
+          <button class="btn btn-danger">Delete</button>
+        </a>
+
       </td>
       </tr>
       {% empty %}

--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -143,7 +143,7 @@
           <a href="{{ file.download_url }}" class="btn btn-secondary btn-sm" target="_blank">Download</a>
       </td>
       <td>
-        <a href="{% url 'main:delete_exp' file.metadata.uuid %}">
+        <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.data.title %}">
           <button class="btn btn-danger">Delete</button>
         </a>
 

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -163,7 +163,11 @@
   </div>
 
   <div class="container story-section">
-  <form action="{% url 'main:share_exp' %}" class="form-context" method="post">
+  {% if uuid %}
+    <form action="{% url 'main:edit_exp' uuid %}" class="form-context" method="post">
+  {% else %}
+    <form action="{% url 'main:share_exp' %}" class="form-context" method="post">
+  {% endif %}
     {% csrf_token %}
     {% regroup form by field.group as field_groups %}
     

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
         name='moderate_public_experiences'),
     re_path(r'^list/?$', views.list_files, name='list'),
     
-    path('delete/<uuid>/', views.delete_experience, name='delete_exp'),
+    path('delete/<uuid>/<title>/', views.delete_experience, name='delete_exp'),
     path('share_exp/', views.share_experience, name='share_exp'),
     path('edit/<uuid>/', views.share_experience, name='edit_exp'),
     

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -1,20 +1,19 @@
-from django.conf.urls import url
-from django.urls import path
+from django.urls import path, re_path
 from server.apps.main import views
 
 app_name = 'main'
 
 urlpatterns = [
-    url(r'^$', views.index, name='index'),
-    url(r'^signup/?$', views.signup, name='signup'),
-    url(r'^signup1/?$', views.signup_frame4_test, name='signup_frame4_test'),
-    url(r'^logout/?$', views.logout_user, name='logout'),
-    url(r'^overview/?$', views.overview, name='overview'),
-    url(r'^view_experiences/?$', views.list_public_experiences,
+    re_path(r'^$', views.index, name='index'),
+    re_path(r'^signup/?$', views.signup, name='signup'),
+    re_path(r'^signup1/?$', views.signup_frame4_test, name='signup_frame4_test'),
+    re_path(r'^logout/?$', views.logout_user, name='logout'),
+    re_path(r'^overview/?$', views.overview, name='overview'),
+    re_path(r'^view_experiences/?$', views.list_public_experiences,
         name='view_experiences'),
-    url(r'^moderate_public_experiences/?$', views.moderate_public_experiences,
+    re_path(r'^moderate_public_experiences/?$', views.moderate_public_experiences,
         name='moderate_public_experiences'),
-    url(r'^list/?$', views.list_files, name='list'),
+    re_path(r'^list/?$', views.list_files, name='list'),
     
     path('delete/<uuid>/', views.delete_experience, name='delete_exp'),
     path('share_exp/', views.share_experience, name='share_exp'),

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -14,9 +14,12 @@ urlpatterns = [
         name='view_experiences'),
     url(r'^moderate_public_experiences/?$', views.moderate_public_experiences,
         name='moderate_public_experiences'),
-    url(r'^share_exp(?:/(?P<edit>(True|False)))?/$', views.share_experience, name='share_exp'),
-    url(r'^delete(?:/(?P<confirmed>(True)))?/', views.delete_experience, name="delete_experience"),
     url(r'^list/?$', views.list_files, name='list'),
+    
+    path('delete/<uuid>/', views.delete_experience, name='delete_exp'),
+    path('share_exp/', views.share_experience, name='share_exp'),
+    path('edit/<uuid>/', views.share_experience, name='edit_exp'),
+    
     path('review_experience/<experience_id>/',
          views.review_experience,
          name='review_experience'),

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -225,6 +225,30 @@ def delete_single_file(uuid, ohmember):
     ohmember.delete_single_file(file_basename=f"{uuid}.json")
     delete_PE(uuid,ohmember)
     
+def get_oh_file(ohmember, uuid):
+    """Returns a single file from OpenHumans, filtered by uuid.
+
+    Args:
+        ohmember : request.user.openhumansmember
+        uuid (str): unique identifier
+
+    Raises:
+        Exception: If uuid belongs to more than one file.
+
+    Returns:
+        file (dict): dictionary representation of OpenHumans file. Returns None if uuid is not matched.
+    """
+    files = ohmember.list_files()
+    file = [f for f in files if f["metadata"]["uuid"]==uuid]
+    
+    if len(file)==0:
+        file=None
+    elif len(file)>1:
+        raise Exception("duplicate uuids in open humans")
+    
+    return file[0]
+    
+
 
 def list_files(request):
     if request.user.is_authenticated:

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -130,6 +130,7 @@ def update_public_experience_db(data, uuid, ohmember, moderation_status = 'not r
 def delete_PE(uuid, ohmember):
     if PublicExperience.objects.filter(experience_id=uuid, open_humans_member=ohmember).exists():
             PublicExperience.objects.get(experience_id=uuid, open_humans_member=ohmember).delete()
+        
     
 def make_uuid():
     return str(uuid.uuid1())
@@ -195,13 +196,13 @@ def make_tags(data):
     
     return tags
     
-def delete_experience(request, confirmed=False):
+def delete_experience(request, uuid, title):
+    # TODO: we currently are passing title via url because it is nice to display it in the confirmation. We could improve the deletion process by having a javascript layover.
+    
     if request.user.is_authenticated:
     
-        uuid = request.POST.get("uuid")
-        title = request.POST.get("title")
+        if request.method == 'POST':
         
-        if confirmed:   
             delete_single_file(uuid = uuid,
                                ohmember = request.user.openhumansmember)
             


### PR DESCRIPTION
Closes #411.

A few changes limit the amount of POST requests:

Url parameters:
- `delete_exp` takes a uuid and title. 
- `edit_exp` takes a uuid. 
     - There is a new helper function, `get_oh_file()`, that, given a uuid, retrieves the file data.

`delete_exp` and `edit_exp` are called as GET requests from the `my_stories` tab (see description in #411).

`POST` requests are only executed when data is to be changed:
- on deletion.
- on submission (of new or edited experience). 

I have also deleted the now-redundant hidden form field `uuid`.

Comments for the future:
- the url passed to `delete_exp` could be very long since it includes the title. It might be nice to do the confirmation on the same page, with javascript, rather than have separate confirmation and success pages.

