### PR TITLE
Implement moderation page

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -46,6 +46,20 @@ class ShareExperienceForm(forms.Form):
     research.group = 3
 
     # hidden field for moderation status
-    moderation_status = forms.BooleanField(widget = forms.HiddenInput(), required=False, initial=False)
+    statuses = [
+        ("not reviewed", "not reviewed"),
+        ("in review", "in review"),
+        ("approved", "approved"),
+        ("rejected", "rejected"),
+        ("", "not reviewed") # hack for default behavour
+    ]
+    moderation_status = forms.ChoiceField(choices = statuses, widget = forms.Select(), required=False)
     moderation_status.group = "hidden"
     
+    def clean_moderation_status(self):
+        mod_status = self.cleaned_data['moderation_status']
+        if not mod_status:
+            mod_status = 'not reviewed'
+            
+        return mod_status
+            

--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -51,7 +51,6 @@ class ShareExperienceForm(forms.Form):
         ("in review", "in review"),
         ("approved", "approved"),
         ("rejected", "rejected"),
-        ("", "not reviewed") # hack for default behavour
     ]
     moderation_status = forms.ChoiceField(choices = statuses, widget = forms.Select(), required=False)
     moderation_status.group = "hidden"

--- a/server/apps/main/templates/main/moderate_public_experiences.html
+++ b/server/apps/main/templates/main/moderate_public_experiences.html
@@ -28,54 +28,139 @@
    <div class="col-lg-12">
      <div class="card-header"><h4>Moderator: </h4></div>
      <div class="card-body">
-     <p>Moderated Experiences: </p>
-      <p>New Experiences in the Platform: </p>
+      <!-- new_experiences = filter(lambda x: x.attr0 == attr0 and x.attr1 == attr1, lst) -->
+     <p>Moderated Experiences: {{ previously_reviewed_experiences.count }} </p>
+     <p>New Experiences in the Platform: {{ unreviewed_experiences.count }} </p>
+     <!-- Accordian Option -->
+     <div id="accordion-moderation">
+      <div class="card">
+        <div class="card-header" id="moderate_new">
+          <h5 class="mb-0">
+            <button class="btn btn-link" data-toggle="collapse" data-target="#collapse_moderate_new" aria-expanded="true" aria-controls="collapse_moderate_new">
+              Moderate New Experiences
+            </button>
+          </h5>
+        </div>
+    
+        <div id="collapse_moderate_new" class="collapse" aria-labelledby="moderate_new" data-parent="#accordion-moderation">
+          <div class="card-body">
+            
+            <table class="table table-responsive-lg table-hover table-striped" style="width:auto">
+              <thead><tr>
+                <th class="number-th" scope="col">Nr.</th>
+                <th class="title-th" scope="col">Title</th>
+                <th class="triggering-label" scope="col">Triggering Labels</th>
+                <th class="title-th" scope="col">Moderate</th>
+                </tr></thead>
+                <tbody>
+                  {% for experience in unreviewed_experiences %}
+                    {% if experience.approved == "not reviewed" %}
+                  <tr>
+                    <th scope="row">{{ forloop.counter }}</th>
+                    <td>{% firstof experience.title_text "notitle" %}</td>
+                    <td>
+                      {% if experience.abuse or experience.violence or experience.drug or experience.mentalhealth or experience.negbody or experience.other %}
+                      <span class="badge badge-warning float-right" style="font-size: 1rem; margin-top:2%">Includes triggering contents</span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      <a href="{% url 'main:moderate_exp' experience.experience_id %}">
+                        <button class="btn btn-primary">Moderate New Experience</button>
+                      </a>
+                  </td>
+                  </tr>
+                    {% endif %}
+                  {% endfor %}
+                </tbody>
+              </table>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-header" id="review_moderated">
+          <h5 class="mb-0">
+            <button class="btn btn-link" data-toggle="collapse" data-target="#collapse_review_moderated" aria-expanded="true" aria-controls="collapse_review_moderated">
+              Review Moderated Experiences
+            </button>
+          </h5>
+        </div>
+    
+        <div id="collapse_review_moderated" class="collapse" aria-labelledby="review_moderated" data-parent="#accordion-moderation">
+          <div class="card-body">
+            
+            <table class="table table-responsive-lg table-hover table-striped" style="width:auto">
+              <thead><tr>
+                <th class="number-th" scope="col">Nr.</th>
+                <th class="title-th" scope="col">Title</th>
+                <th class="triggering-label" scope="col">Triggering Labels</th>
+                <th class="moderation-status" scope="col">Moderation Status</th>
+                <th class="title-th" scope="col">Moderate</th>
+                </tr></thead>
+                <tbody>
+                  {% for experience in previously_reviewed_experiences %}
+                    {% if experience.approved != "not reviewed" %}
+                  <tr>
+                    <th scope="row">{{ forloop.counter }}</th>
+                    <td>{% firstof experience.title_text "notitle" %}</td>
+                    <td>
+                      {% if experience.abuse or experience.violence or experience.drug or experience.mentalhealth or experience.negbody or experience.other %}
+                        <span class="badge badge-warning float-right" style="font-size: 1rem; margin-top:2%">Includes triggering contents</span>
+                      {% endif %}
+                    </td>
+                    <td>{{ experience.approved }}</td>
+                    <td>
+                      <a href="{% url 'main:moderate_exp' experience.experience_id %}">
+                        <button class="btn btn-primary">Review Moderated Experience</button>
+                      </a>
+                  </td>
+                  </tr>
+                    {% endif %}
+                  {% endfor %}
+                </tbody>
+              </table>
+          </div>
+        </div>
+      </div>
+
+
+      <div class="card">
+        <div class="card-header" id="questions">
+          <h5 class="mb-0">
+            <button class="btn btn-link" data-toggle="collapse" data-target="#collapse_questions" aria-expanded="true" aria-controls="collapse_questions">
+              Questions
+            </button>
+          </h5>
+        </div>
+    
+        <div id="collapse_questions" class="collapse" aria-labelledby="questions" data-parent="#accordion-moderation">
+          <div class="card-body">
+            Google Form for Questions Collection
+          </div>
+        </div>
+      </div>
+
+
+      </div>
 <!--    Google Form for Questions Collection-->
-         <a class="col-lg-4" href="#"><button class="btn btn-outline-primary btn-lg "
-                                              type="button">Moderate New
-    Experiences</button>
-   </a>
-    <a class="col-lg-4" href="#"><button class="btn btn-outline-primary btn-lg " type="button">Review
-      Moderated Experiences</button>
-   </a>
-        <a class="col-lg-4" href="#"><button class="btn btn-outline-primary btn-lg " type="button">
-          Questions</button>
-   </a>
+      <!-- <a class="col-lg-4" href="#">
+      <button class="btn btn-outline-primary btn-lg "ntype="button">Moderate New Experiences
+      </button></a>
+      <a class="col-lg-4" href="#">
+      <button class="btn btn-outline-primary btn-lg " type="button">Review Moderated Experiences
+      </button></a>
+      <a class="col-lg-4" href="#">
+      <button class="btn btn-outline-primary btn-lg " type="button"> Questions
+      </button></a> -->
+
      </div>
+
    </div>
   </div>
 </section>
 <!--CTA-->
 <section id="cta">
 
-</section>
-
-
-<!-- Helen Faff -->
-<section id="in-review-public-experiences">
-  <div class="in-review-table-container">
-    <table class="table table-responsive-lg table-hover table-striped" style="width:auto">
-      <thead><tr>
-        <th class="number-th" scope="col">Nr.</th>
-        <th class="title-th" scope="col">Title</th>
-        <th class="title-th" scope="col">Moderate</th>
-        </tr></thead>
-        <tbody>
-          {% for experience in experiences %}
-          <tr>
-            <th scope="row">{{ forloop.counter }}</th>
-            <td>{% firstof experience.title_text "notitle" %}</td>
-            <td>
-              <a href="{% url 'main:moderate_exp' experience.experience_id %}">
-                <button class="btn btn-primary">Moderate</button>
-              </a>
-          </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-          </table>
-
-  </div>
 </section>
 
 

--- a/server/apps/main/templates/main/moderate_public_experiences.html
+++ b/server/apps/main/templates/main/moderate_public_experiences.html
@@ -49,6 +49,36 @@
 <section id="cta">
 
 </section>
+
+
+<!-- Helen Faff -->
+<section id="in-review-public-experiences">
+  <div class="in-review-table-container">
+    <table class="table table-responsive-lg table-hover table-striped" style="width:auto">
+      <thead><tr>
+        <th class="number-th" scope="col">Nr.</th>
+        <th class="title-th" scope="col">Title</th>
+        <th class="title-th" scope="col">Moderate</th>
+        </tr></thead>
+        <tbody>
+          {% for experience in experiences %}
+          <tr>
+            <th scope="row">{{ forloop.counter }}</th>
+            <td>{% firstof experience.title_text "notitle" %}</td>
+          </tr>
+          <td>
+            <a href="{% url 'main:moderate_exp' experience.experience_id %}">
+              <button class="btn btn-primary">Edit</button>
+            </a>
+        </td>
+          {% endfor %}
+        </tbody>
+          </table>
+
+  </div>
+</section>
+
+
 <!--Footer-->
 <section id="footer">
    <div class="container-fluid">

--- a/server/apps/main/templates/main/moderate_public_experiences.html
+++ b/server/apps/main/templates/main/moderate_public_experiences.html
@@ -65,12 +65,12 @@
           <tr>
             <th scope="row">{{ forloop.counter }}</th>
             <td>{% firstof experience.title_text "notitle" %}</td>
+            <td>
+              <a href="{% url 'main:moderate_exp' experience.experience_id %}">
+                <button class="btn btn-primary">Moderate</button>
+              </a>
+          </td>
           </tr>
-          <td>
-            <a href="{% url 'main:moderate_exp' experience.experience_id %}">
-              <button class="btn btn-primary">Edit</button>
-            </a>
-        </td>
           {% endfor %}
         </tbody>
           </table>

--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -125,7 +125,7 @@
           {% endfor %}
       </td>
       <td>
-        status...
+        {% firstof file.metadata.data.moderation_status "Moderation Status Unknown" %}
       </td>
       <td>
         {% for tag in file.metadata.tags %}

--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -57,8 +57,20 @@
           <h3 class="story-head card-header process">In Process</h3>
           <div class="card-body">
             <ul>
-              <li class="list-item"><p class="card-text">Waiting:<span> 2 stories</span></p></li>
-              <li class="list-item"><p class="card-text">Moderating:<span> 1 story</span></p></li>
+              <li class="list-item"><p class="card-text">Waiting:<span> {{ n_not_reviewed }}
+              {% if n_not_reviewed == 1 %}
+                story
+              {% else %}
+                stories
+              {%endif%}
+              </span></p></li>
+              <li class="list-item"><p class="card-text">Moderating:<span> {{ n_in_review }}
+              {% if n_in_review == 1 %}
+                story
+              {% else %}
+                stories
+              {%endif%}
+              </span></p></li>
               <li class="list-item"><p class="card-text">Re-moderating<span> 0 story</span></p></li>
 
             </ul>
@@ -70,9 +82,27 @@
           <h3 class="story-head card-header submitted">Moderated</h3>
           <div class="card-body">
             <ul>
-              <li class="list-item"><p class="card-text">Moderated:<span> 3 stories</span></p></li>
-              <li class="list-item"><p class="card-text">Accepted:<span> 3 stories</span></p></li>
-              <li class="list-item"><p class="card-text">Rejected:<span> 0 story</span></p></li>
+              <li class="list-item"><p class="card-text">Moderated:<span> {{ n_moderated }}
+              {% if n_moderated == 1 %}
+                story
+              {% else %}
+                stories
+              {%endif%}
+              </span></p></li>
+              <li class="list-item"><p class="card-text">Approved:<span> {{ n_approved }} 
+              {% if n_accepted == 1 %}
+                story
+              {% else %}
+                stories
+              {%endif%}
+              </span></p></li>
+              <li class="list-item"><p class="card-text">Rejected:<span> {{ n_rejected }}
+              {% if n_rejected == 1 %}
+                story
+              {% else %}
+                stories
+              {%endif%}
+              </span></p></li>
             </ul>
           </div>
         </div>

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -173,7 +173,13 @@
     
     {% for group in field_groups %}
       {% if group.grouper == "hidden" %}
-        {% for field in group.list %} {{ field }} {% endfor %}
+        {% if moderate %} 
+          <div class="form-group">
+            <h3><label>Moderation Status</label></label></h3>
+            <div class="row">
+            {% for field in group.list %} {{ field }}{% endfor %}
+           </div>
+        {% endif %}
       {% elif group.grouper == 1 %}
   
         {% for field in group.list %}

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -18,7 +18,8 @@ urlpatterns = [
     path('delete/<uuid>/<title>/', views.delete_experience, name='delete_exp'),
     path('share_exp/', views.share_experience, name='share_exp'),
     path('edit/<uuid>/', views.share_experience, name='edit_exp'),
-    
+    path('moderate/<uuid>/', views.moderate_experience, name='moderate_exp'),
+
     path('review_experience/<experience_id>/',
          views.review_experience,
          name='review_experience'),

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -7,8 +7,10 @@ import uuid
 import requests
 from django.conf import settings
 from django.contrib.auth import login, logout
+from django.forms.models import model_to_dict 
 from django.shortcuts import redirect, render
 from openhumans.models import OpenHumansMember
+
 
 from .models import PublicExperience
 
@@ -430,4 +432,27 @@ def what_autism_is(request):
 
 def footer(request):
     return render(request, "main/footer.html")
+
+def moderate_experience(request, uuid):
+    model = PublicExperience.objects.get(experience_id = uuid)
+    form = model_to_form(model)
+    return render(request, 'main/share_experiences.html', {'form': form, 'uuid':uuid})  
+
+def model_to_form(model):
+    model_dict = model_to_dict(model)
+
+    form = ShareExperienceForm({
+        "experience": model_dict["experience_text"],
+        "wish_different": model_dict["difference_text"],
+        "title":model_dict["title_text"],
+        "abuse":model_dict["abuse"],
+        "violence":model_dict["violence"],
+        "drug":model_dict["drug"],
+        "mentalhealth":model_dict["mentalhealth"],
+        "negbody":model_dict["negbody"],
+        "other":model_dict["other"],
+        "approved":model_dict["approved"]
+    })
+
+    return form
 

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -60,7 +60,6 @@ def share_experience(request, uuid=False):
 
             if form.is_valid():
                 
-                
                 if uuid: 
                     # we will be here if we are editing a record that already exists               
                     # for OH we need to Delete before reupload.
@@ -434,12 +433,14 @@ def footer(request):
     return render(request, "main/footer.html")
 
 def moderate_experience(request, uuid):
+    print("______________MOD_____________")
     model = PublicExperience.objects.get(experience_id = uuid)
     form = model_to_form(model)
-    return render(request, 'main/share_experiences.html', {'form': form, 'uuid':uuid})  
+    return render(request, 'main/share_experiences.html', {'form': form, 'uuid':uuid, 'moderate':True})  
 
 def model_to_form(model):
     model_dict = model_to_dict(model)
+    print(model_dict)
 
     form = ShareExperienceForm({
         "experience": model_dict["experience_text"],

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -10,6 +10,7 @@ from django.contrib.auth import login, logout
 from django.forms.models import model_to_dict 
 from django.shortcuts import redirect, render
 from openhumans.models import OpenHumansMember
+from django.db.models import Q
 
 
 from .models import PublicExperience
@@ -273,11 +274,16 @@ def list_public_experiences(request):
 
 
 def moderate_public_experiences(request):
-    experiences = PublicExperience.objects.filter(approved='not reviewed')
+
+    unreviewed_experiences = PublicExperience.objects.filter(approved='not reviewed')
+
+    previously_reviewed_experiences = PublicExperience.objects.filter(~Q(approved='not reviewed'))
+
     return render(
         request,
         'main/moderate_public_experiences.html',
-        context={'experiences': experiences})
+        context={"unreviewed_experiences": unreviewed_experiences,
+        "previously_reviewed_experiences": previously_reviewed_experiences})
 
 
 def review_experience(request, experience_id):
@@ -433,7 +439,6 @@ def footer(request):
     return render(request, "main/footer.html")
 
 def moderate_experience(request, uuid):
-    print("______________MOD_____________")
     model = PublicExperience.objects.get(experience_id = uuid)
     form = model_to_form(model)
     return render(request, 'main/share_experiences.html', {'form': form, 'uuid':uuid, 'moderate':True})  

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -401,9 +401,29 @@ def registration(request):
 def signup_frame4_test(request):
     return render(request, "main/signup1.html")
 
+def get_review_status(context):
+        not_reviewed = 0
+        approved = 0
+        rejected = 0
+        for item in context['files']:
+            if item['metadata']['data']['viewable']:
+                if item['metadata']['data']['moderation_status'] == "not reviewed":
+                    not_reviewed += 1
+                elif item['metadata']['data']['moderation_status'] == 'approved':
+                    approved += 1
+                elif item['metadata']['data']['moderation_status'] == 'rejected':
+                    rejected += 1
+        viewable = not_reviewed + approved + rejected
+        return viewable, not_reviewed, approved, rejected
+    
 def my_stories(request):
     if request.user.is_authenticated:
         context = {'files': request.user.openhumansmember.list_files()}
+        viewable, not_reviewed, approved, rejected = get_review_status(context)
+        context['n_viewable'] = viewable
+        context["n_not_reviewed"] = not_reviewed
+        context['n_approved'] = approved
+        context['n_rejected'] = rejected
         return render(request, "main/my_stories.html", context)
     else:
         return redirect("main:overview")

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -67,7 +67,7 @@ def share_experience(request, uuid=False):
                 
                 else:
                     uuid = make_uuid()
-                    
+                                
                 upload(data = form.cleaned_data, uuid = uuid, ohmember = request.user.openhumansmember)                
                 
                 # for Public Experience we need to check if it's viewable and update accordingly.
@@ -92,7 +92,7 @@ def share_experience(request, uuid=False):
     else:    
         return redirect('index')
 
-def update_public_experience_db(data, uuid, ohmember, moderation_status = 'not reviewed'):
+def update_public_experience_db(data, uuid, ohmember):
     """Updates the public experience database for the given uuid.
     
     If data is tagged as viewable, an experience will be updated or inserted.
@@ -117,8 +117,8 @@ def update_public_experience_db(data, uuid, ohmember, moderation_status = 'not r
             drug=data['drug'],
             mentalhealth=data['mentalhealth'],
             negbody=data['negbody'],
-            other=True if data['other'] != '' else False,
-            approved=moderation_status
+            other=data['other'],
+            approved=data['moderation_status']
         )
         
         # .save() updates if primary key exists, inserts otherwise. 


### PR DESCRIPTION
PR to address tasks raised in #162. Copied below for information:

> ### Tasks
> - [x] Populate a table of experiences, tagged with "review"
> - [x] Add an approve button that sets the moderation state of the experience to "Accepted/Approved/Public"
> - [x] Add a reject button that sets the moderation state of the experience to "Rejected"


moderate_public_experiences has been updated to receive both un-moderated and moderated experiences from the (local) database of PublicExperience objects.

Moderators can access either by clicking on the accordion link and getting a list of the relevant experiences.

The "moderate new experience" or "review moderated experience" buttons take the moderators back to the shared_experiences form as a user would see if they were editing their own experience. With the addition of a moderation drop down menu to change the status.

Additional follow on work separated into issue #418 