### PR TITLE
Set up Admin pages and permissions

### DIFF
--- a/server/apps/main/templates/main/partials/navigation.html
+++ b/server/apps/main/templates/main/partials/navigation.html
@@ -1,4 +1,6 @@
  {% load static %}
+ {% load custom_tags %}
+
 <!--    Stylesheet-->
   <link href="{% static '/css/navigation_light.css' %}" rel="stylesheet" id="mystylesheet">
 
@@ -27,7 +29,10 @@
         <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
           <a class="dropdown-item" href="{% url 'main:view_experiences' %}">View Stories</a>
           <a class="dropdown-item" href="{% url 'main:share_exp' %}">Share Stories</a>
-          <a class="dropdown-item" href="{% url 'main:moderate_public_experiences' %}">Moderate</a>
+          {% is_moderator user as moderator %}
+          {% if moderator %}
+            <a class="dropdown-item" href="{% url 'main:moderate_public_experiences' %}">Moderate</a>
+          {% endif %}
           <a class="dropdown-item" href="{% url 'main:list' %}">File list</a>
         </div>
       </li>

--- a/server/apps/main/templatetags/custom_tags.py
+++ b/server/apps/main/templatetags/custom_tags.py
@@ -1,4 +1,6 @@
 from django import template
+from django.contrib.auth.models import Group
+
 register = template.Library()
 
 @register.simple_tag
@@ -11,3 +13,18 @@ def toggle_story(val):
     return 'story'
   else:
     return 'stories'
+  
+@register.simple_tag
+def is_moderator(user):
+  """return boolean if membership of moderator group"""
+  
+  try:
+    group = Group.objects.get(user=user)
+    return (group.name == "Moderators")
+  
+  except Group.DoesNotExist:
+    return False
+
+  
+  
+  

--- a/server/apps/main/templatetags/custom_tags.py
+++ b/server/apps/main/templatetags/custom_tags.py
@@ -1,5 +1,6 @@
 from django import template
-from django.contrib.auth.models import Group
+# from django.contrib.auth.models import Group
+from ..views import is_moderator
 
 register = template.Library()
 
@@ -14,17 +15,5 @@ def toggle_story(val):
   else:
     return 'stories'
   
-@register.simple_tag
-def is_moderator(user):
-  """return boolean if membership of moderator group"""
-  
-  try:
-    group = Group.objects.get(user=user)
-    return (group.name == "Moderators")
-  
-  except Group.DoesNotExist:
-    return False
-
-  
-  
+register.simple_tag(is_moderator)  
   

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -11,6 +11,7 @@ from django.forms.models import model_to_dict
 from django.shortcuts import redirect, render
 from openhumans.models import OpenHumansMember
 from django.db.models import Q
+from django.contrib.auth.models import Group
 
 
 from .models import PublicExperience
@@ -274,15 +275,18 @@ def list_public_experiences(request):
 
 
 def moderate_public_experiences(request):
+    user_status = Group.objects.get(user=request.user).name
+    if user_status == "Moderators":
+        unreviewed_experiences = PublicExperience.objects.filter(moderation_status='not reviewed')
+        previously_reviewed_experiences = PublicExperience.objects.filter(~Q(moderation_status='not reviewed'))
+        return render(
+            request,
+            'main/moderate_public_experiences.html',
+            context={"unreviewed_experiences": unreviewed_experiences,
+            "previously_reviewed_experiences": previously_reviewed_experiences})
+    else:
+        return redirect("main:overview")
 
-    unreviewed_experiences = PublicExperience.objects.filter(approved='not reviewed')
-    previously_reviewed_experiences = PublicExperience.objects.filter(~Q(approved='not reviewed'))
-
-    return render(
-        request,
-        'main/moderate_public_experiences.html',
-        context={"unreviewed_experiences": unreviewed_experiences,
-        "previously_reviewed_experiences": previously_reviewed_experiences})
 
 
 def review_experience(request, experience_id):


### PR DESCRIPTION
Addressing issue #166 copied below

> ## Description
> User roles/permissions will be managed through the Django admin panel. An admin by default will be able to view, manipulate, and remove all data and users. However, the primary utility for feature will be assigning which users are moderators. 
> 
> ### Tasks
> Users use their OpenHumans credentials to utilize the site. 
> - [x] Create a new or use the pre-existing users table, provided in the Django admin library, and create a foreign key on the OpenHumans user ID
> - [x] Create a Moderator status
> - [x] Allow admin to set a user as moderator
> - [x] Allow admin to set a moderator as a user
> - [ ] Add documentation on how to create an admin user for development


Custom template tag to limit permissions based on user status (see below)

