### PR TITLE
Reformat datetime for My Stories

### DIFF
--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -434,10 +434,20 @@ def get_review_status(files):
 
     return statuses
 
+def reformat_date_string(context):
+    """
+    Reformat the sting that contains the datetime to a more usable format
+    """
+    old_format = '%Y-%m-%dT%H:%M:%S.%fZ'
+    new_format = '%d-%b-%Y %H:%M'
+    for file in context['files']:
+        file['created'] = datetime.datetime.strptime(file['created'], old_format).strftime(new_format)
+    return context
     
 def my_stories(request):
     if request.user.is_authenticated:
         context = {'files': request.user.openhumansmember.list_files()}
+        context = reformat_date_string(context)
         statuses = get_review_status(context['files'])
         context = {**context, **statuses}
         return render(request, "main/my_stories.html", context)


### PR DESCRIPTION
Currently the creation date is read from the OH files as a string and is in an unnecessarily long form 

> 2023-01-30T15:40:39.857995Z

This inelegant solution reformats the string to a more compact (and readable) form

> 30-Jan-2023 15:40

A nicer solution would be to edit the time format in `settings.py` but I am not sure what else uses it and it may cause problems elsewhere in the code - what do you think @callummole?