### PR TITLE
Align model and form

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -2,12 +2,12 @@ from django import forms
 
 class ShareExperienceForm(forms.Form):
         
-    experience_text = forms.CharField(label='Please share your story', max_length=500, strip=True,
-                                 widget=forms.Textarea(attrs={'placeholder':'Write your story here',
+    experience_text = forms.CharField(label='Please share your experience', max_length=500, strip=True,
+                                 widget=forms.Textarea(attrs={'placeholder':'Write your experience here, you can take as much or little space as you need.',
                                                               'rows':'4',
                                                               'class':'form-control'}))
     experience_text.group = 1
-    difference_text = forms.CharField(label='Suggestions for what could have made your story better',
+    difference_text = forms.CharField(label='What could have made your experience better?',
                                      strip=True, max_length=500,
                                      widget=forms.Textarea(attrs={'placeholder':'Do you have anything that you would want to have changed to make it better? Or do you have any tips for others who may experience the same thing?',
                                                               'rows':'4',

--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -2,23 +2,23 @@ from django import forms
 
 class ShareExperienceForm(forms.Form):
         
-    experience = forms.CharField(label='Please share your story', max_length=500, strip=True,
+    experience_text = forms.CharField(label='Please share your story', max_length=500, strip=True,
                                  widget=forms.Textarea(attrs={'placeholder':'Write your story here',
                                                               'rows':'4',
                                                               'class':'form-control'}))
-    experience.group = 1
-    wish_different = forms.CharField(label='Suggestions for what could have made your story better',
+    experience_text.group = 1
+    difference_text = forms.CharField(label='Suggestions for what could have made your story better',
                                      strip=True, max_length=500,
                                      widget=forms.Textarea(attrs={'placeholder':'Write your story here',
                                                               'rows':'4',
                                                               'class':'form-control'}))
-    wish_different.group = 1
-    title = forms.CharField(label='Choose a title for your story', 
+    difference_text.group = 1
+    title_text = forms.CharField(label='Choose a title for your story', 
                             strip=True,
                             max_length=150,
                             widget=forms.TextInput(attrs={'placeholder':'Title',
                                                           'class':'form-control'}))
-    title.group = 1
+    title_text.group = 1
     
     
     
@@ -66,7 +66,7 @@ class ShareExperienceForm(forms.Form):
 
                 
         for field in self.fields:
-            if field in ['experience','wish_different','title','research','viewable']: 
+            if field in ['experience_text','difference_text','title_text','research','viewable']: 
                 self.fields[field].widget.attrs['disabled']= disable_moderator or disable_all
             else:
                 self.fields[field].widget.attrs['disabled']= disable_all

--- a/server/apps/main/templates/main/my_stories.html
+++ b/server/apps/main/templates/main/my_stories.html
@@ -121,7 +121,7 @@
       {% for file in files %}
       <tr>
         <th scope="row">{{ forloop.counter }}</th>
-        <td>{% firstof file.metadata.data.title "notitle" %}</td>
+        <td>{% firstof file.metadata.description "notitle" %}</td>
         <td>{% firstof file.created|naturaltime "Creation date unknown" %}</td>
         <td>
           {% for tag in file.metadata.tags %}
@@ -154,7 +154,7 @@
           <a href="{{ file.download_url }}" class="btn btn-secondary btn-sm" target="_blank">Download</a>
       </td>
       <td>
-        <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.data.title %}">
+        <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.description %}">
           <button class="btn btn-danger">Delete</button>
         </a>
 

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -118,22 +118,10 @@ def update_public_experience_db(data, uuid, ohmember):
         moderation_status (str, optional): Defaults to 'in review'.
     """
     
-    if data['viewable']:
+    if data.pop('viewable',False):
         
-        pe = PublicExperience(experience_text=data['experience'],
-            difference_text=data['wish_different'],
-            title_text=data['title'],
-            open_humans_member=ohmember,
-            experience_id=uuid,
-            abuse=data['abuse'],
-            violence=data['violence'],
-            drug=data['drug'],
-            mentalhealth=data['mentalhealth'],
-            negbody=data['negbody'],
-            other=data['other'],
-            moderation_status=data['moderation_status'],
-            research = data['research']
-        )
+        pe = PublicExperience( open_humans_member=ohmember,
+            experience_id=uuid, **data)
         
         # .save() updates if primary key exists, inserts otherwise. 
         pe.save()        
@@ -166,7 +154,7 @@ def upload(data, uuid, ohmember):
     # by saving the output json into metadata we can access the fields easily through request.user.openhumansmember.list_files().
     metadata = {
         'uuid': uuid,   
-        'description': data.get('title'),
+        'description': data.get('title_text'),
         'tags': make_tags(data),
         **output_json,
         }
@@ -552,19 +540,8 @@ def moderate_experience(request, uuid):
 def model_to_form(model, disable_moderator = False):
     model_dict = model_to_dict(model)
 
-    form = ShareExperienceForm({
-        "experience": model_dict["experience_text"],
-        "wish_different": model_dict["difference_text"],
-        "title":model_dict["title_text"],
-        "abuse":model_dict["abuse"],
-        "violence":model_dict["violence"],
-        "drug":model_dict["drug"],
-        "mentalhealth":model_dict["mentalhealth"],
-        "negbody":model_dict["negbody"],
-        "other":model_dict["other"],
-        "viewable":True, #we only moderate public experiences
-        "research":model_dict["research"],
-        "moderation_status":model_dict["moderation_status"]
+    form = ShareExperienceForm({**model_dict,
+        "viewable":True #we only moderate public experiences
     }, disable_moderator=disable_moderator)
 
     return form


### PR DESCRIPTION
I have changed the field names in `ShareExperienceForm` to match those in our `PublicExperience` model.

This means that we can much more concisely map from one to the other.

I have kept the form as a `Form` rather than a `ModelForm`, since this would require unnecessary refactoring without much gain in conciseness or understanding, I think. 