### PR TITLE
Store UUID in public experiences correctly

### DIFF
--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -210,18 +210,20 @@
 
     {% if readonly %}
       </form>
-      <div class="form-group">
-        <a href="{% url 'main:edit_exp' uuid %}">
-          <button class="btn btn-primary btn-lg float-right">Edit</button>
-        </a>
-      </div>
+    </div>
+    <div class="form-group">
+      <a href="{% url 'main:edit_exp' uuid %}">
+        <button class="btn btn-primary btn-lg float-right">Edit</button>
+      </a>
+    </div>
     {% else %}
       <div class='form-group'>
         <input type="submit" class="btn btn-outline-dark btn-lg float-right" value="Submit">
       </div>
     </form>
-    {% endif %}
   </div>
+    {% endif %}
+
 
 </section>
 

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -125,8 +125,9 @@ def update_public_experience_db(data, uuid, ohmember):
 
     if data.pop('viewable',False):
         data.pop('open_humans_member', None) # Remove from dict as needs to be an object not string
+        data.pop('experience_id', None) # Remove from dict as needs to be an object not string
         
-        pe = PublicExperience( open_humans_member=ohmember, **data)
+        pe = PublicExperience(open_humans_member=ohmember, experience_id=uuid, **data)
         
         # .save() updates if primary key exists, inserts otherwise. 
         pe.save()     


### PR DESCRIPTION
This closes  #445 

I noticed that it was only the passing of the `uuid` to the creation method that was missing to allow the moderation to work as expected. The second change was to then remove the potentially duplicate UUID that would be present when editing existing experiences.