### PR TITLE
Cleanup metadata stored on OpenHuman

### DIFF
--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -110,6 +110,7 @@ def get_review_status(files):
     return statuses
 
 
+# @vcr.use_cassette("tmp/get_oh_metadata.yaml", filter_query_parameters=['access_token'])
 def get_oh_metadata(ohmember, uuid):
     """Returns the metadata for a single file from OpenHumans, filtered by uuid.
 
@@ -133,6 +134,7 @@ def get_oh_metadata(ohmember, uuid):
 
     return file[0]
 
+# @vcr.use_cassette("tmp/get_oh_file.yaml", filter_query_parameters=['access_token'])
 def get_oh_file(url):
     """Returns a single file from OpenHumans.
 
@@ -150,6 +152,7 @@ def get_oh_file(url):
 
     return data
 
+# @vcr.use_cassette("tmp/get_oh_combined.yaml", filter_query_parameters=['access_token'])
 def get_oh_combined(ohmember, uuid):
     """Returns a dictionary combining file and metadata from OpenHumans, filtered by uuid.
 

--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -2,11 +2,12 @@ import datetime
 import json
 import io
 import uuid
+import requests
 from django.contrib.auth.models import Group
 from django.forms.models import model_to_dict
+from django.conf import settings
 from .forms import ModerateExperienceForm
 from .models import PublicExperience, ExperienceHistory
-
 
 def is_moderator(user):
     """Return membership of moderator group."""
@@ -109,8 +110,8 @@ def get_review_status(files):
     return statuses
 
 
-def get_oh_file(ohmember, uuid):
-    """Returns a single file from OpenHumans, filtered by uuid.
+def get_oh_metadata(ohmember, uuid):
+    """Returns the metadata for a single file from OpenHumans, filtered by uuid.
 
     Args:
         ohmember : request.user.openhumansmember
@@ -120,7 +121,7 @@ def get_oh_file(ohmember, uuid):
         Exception: If uuid belongs to more than one file.
 
     Returns:
-        file (dict): dictionary representation of OpenHumans file. Returns None if uuid is not matched.
+        metadata (dict): dictionary representation of OpenHumans file metadata. Returns None if uuid is not matched.
     """
     files = ohmember.list_files()
     file = [f for f in files if f["metadata"]["uuid"] == uuid]
@@ -132,6 +133,46 @@ def get_oh_file(ohmember, uuid):
 
     return file[0]
 
+def get_oh_file(url):
+    """Returns a single file from OpenHumans.
+
+    Args:
+        url (str): the url of the file
+
+    Returns:
+        file (dict): dictionary representation of OpenHumans file. Returns an empty dict if the file can't be accessed.
+    """
+    data = {}
+    # Download the file from OpenHumans
+    response = requests.get(url)
+    if response.status_code == 200:
+        data = response.json()
+
+    return data
+
+def get_oh_combined(ohmember, uuid):
+    """Returns a dictionary combining file and metadata from OpenHumans, filtered by uuid.
+
+    Args:
+        ohmember : request.user.openhumansmember
+        uuid (str): unique identifier
+
+    Raises:
+        Exception: If uuid belongs to more than one file.
+
+    Returns:
+        combined (dict): dictionary representation of combined OpenHumans file and metadata. Returns an empty dict if uuid is not matched.
+    """
+    metadata = get_oh_metadata(ohmember, uuid)
+
+    data = {}
+    url = metadata.get('download_url') if metadata else None
+    # Should we do more sanity checking of the URL?
+    # E.g. check it starts with https://www.openhumans.org/... ?
+    if url:
+        data = get_oh_file(url)
+
+    return rebuild_experience_data(data, metadata)
 
 def delete_single_file_and_pe(uuid, ohmember):
     """Deletes a given file id and uuid from openhumans and ensures absence from local PublicExperiences database.
@@ -152,12 +193,6 @@ def make_tags(data):
     tag_map = {
         "viewable": {"True": "public", "False": "not public"},
         "research": {"True": "research", "False": "non-research"},
-        "drug": {"True": "drugs", "False": ""},
-        "abuse": {"True": "abuse", "False": ""},
-        "negbody": {"True": "negative body", "False": ""},
-        "violence": {"True": "violence", "False": ""},
-        "mentalhealth": {"True": "mental health", "False": ""},
-        "moderation_status": {"True": "", "False": "in review"},
     }
 
     tags = [tag_map[k].get(str(v)) for k, v in data.items() if k in tag_map.keys()]
@@ -167,6 +202,16 @@ def make_tags(data):
     tags = [tag for tag in tags if bool(tag) == True]
     return tags
 
+def prepare_metadata(uuid, timestring, data):
+    # The description is truncated to DESCRIPTION_LEN_MAX (100) characters as
+    # this is the maximum supported by OpenHumans
+    return {
+        "uuid": uuid,
+        "description": data.get("title_text")[:settings.DESCRIPTION_LEN_MAX],
+        "tags": make_tags(data),
+        "timestamp": timestring,
+        "data": {k: v for k, v in data.items() if k not in settings.METADATA_MASK},
+    }
 
 def upload(data, uuid, ohmember):
     """Uploads a dictionary representation of an experience to open humans.
@@ -177,15 +222,11 @@ def upload(data, uuid, ohmember):
         ohmember : request.user.openhumansmember
     """
 
-    output_json = {"data": data, "timestamp": str(datetime.datetime.now())}
+    timestring = str(datetime.datetime.now())
+    output_json = {"data": data, "timestamp": timestring}
 
     # by saving the output json into metadata we can access the fields easily through request.user.openhumansmember.list_files().
-    metadata = {
-        "uuid": uuid,
-        "description": data.get("title_text"),
-        "tags": make_tags(data),
-        **output_json,
-    }
+    metadata = prepare_metadata(uuid, timestring, data)
 
     # create stream for OH upload
     output = io.StringIO()
@@ -198,6 +239,59 @@ def upload(data, uuid, ohmember):
         metadata=metadata,
     )
 
+def rebuild_experience_data(data, metadata):
+    """Combines file data with metadata into a consistent format.
+
+    In case values appear in both the file data and metadata, the
+    metadata values will take priority.
+
+    The file data should be in the following form:
+    {
+        "data": {
+            "experience_text": "...",
+            "difference_text": "...",
+            "title_text": "...",
+            ...
+        },
+        ...
+    }
+
+    The metadata should be in the following form:
+    {
+        "download_url": "https://www.openhumans.org/..",
+        "metadata": {
+            "data": {
+                "other": ...,
+                ...
+            },
+            "tags": [...],
+            ...
+          },
+          ...
+    }
+
+    The returned structure will be in the following form:
+    {
+        "experience_text": "...",
+        "difference_text": "...",
+        "title_text": "...",
+        "other": "...",
+        "moderation_status": "..."
+        ...
+    }
+
+    Args:
+        data (dict): the file data
+        metadata (dict): the metadata
+
+    Returns:
+        combined (dict): combined file and metadata dictionary
+    """
+
+    combined = {k: v for k, v in data["data"].items() if k in settings.METADATA_MASK}
+    # Using dict.update the metadata values will take priority
+    combined.update(metadata["metadata"]["data"])
+    return combined
 
 def make_uuid():
     """Create a Universal Unique Identifier."""

--- a/server/apps/main/tests/fixtures/get_oh_combined.yaml
+++ b/server/apps/main/tests/fixtures/get_oh_combined.yaml
@@ -1,0 +1,124 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://www.openhumans.org/api/direct-sharing/project/exchange-member/
+  response:
+    body:
+      string: '{"count":4,"next":null,"previous":null,"created":"2023-04-03T14:09:46.906398Z","project_member_id":"39896706","sources_shared":[],"data":[{"id":63958265,"basename":"c72743e2-d229-11ed-99b0-0242ac140003.json","created":"2023-04-04T08:18:13.696771Z","datatypes":[],"download_url":"https://www.openhumans.org/data-management/datafile-download/63958265/?key=0512b6e2-8e71-4ae2-aa77-cc2fb5148652","metadata":{"data":{"drug":false,"abuse":false,"other":"","negbody":false,"research":false,"viewable":true,"violence":false,"mentalhealth":false,"experience_id":"c72743e2-d229-11ed-99b0-0242ac140003","moderation_status":"approved","open_humans_member":"39896706"},"tags":["non-research","public"],"uuid":"c72743e2-d229-11ed-99b0-0242ac140003","timestamp":"2023-04-04
+        08:18:12.889809","description":"Experiences"},"source":"direct-sharing-1330","source_project":"https://www.openhumans.org/api/public/project/1330/"},{"id":63958266,"basename":"be683784-d23d-11ed-becb-0242ac140003.json","created":"2023-04-04T08:18:24.980311Z","datatypes":[],"download_url":"https://www.openhumans.org/data-management/datafile-download/63958266/?key=cffb6bcc-b05e-4584-9c21-98da6c85cb9f","metadata":{"data":{"drug":false,"abuse":false,"other":"","negbody":true,"research":false,"viewable":true,"violence":false,"mentalhealth":false,"experience_id":"be683784-d23d-11ed-becb-0242ac140003","moderation_status":"approved","open_humans_member":"39896706"},"tags":["non-research","public"],"uuid":"be683784-d23d-11ed-becb-0242ac140003","timestamp":"2023-04-04
+        08:18:24.182982","description":"Experience"},"source":"direct-sharing-1330","source_project":"https://www.openhumans.org/api/public/project/1330/"},{"id":63963887,"basename":"2f9d9644-d2d7-11ed-9338-0242ac140003.json","created":"2023-04-04T10:55:18.520710Z","datatypes":[],"download_url":"https://www.openhumans.org/data-management/datafile-download/63963887/?key=35f3088c-a729-4ecd-8788-e7e41917fd53","metadata":{"data":{"drug":true,"abuse":false,"other":"topic","negbody":false,"research":false,"viewable":false,"violence":false,"mentalhealth":true,"moderation_status":"not
+        reviewed"},"tags":["not public","non-research","Other triggering label"],"uuid":"2f9d9644-d2d7-11ed-9338-0242ac140003","timestamp":"2023-04-04
+        10:55:17.707917","description":"Experiences 4"},"source":"direct-sharing-1330","source_project":"https://www.openhumans.org/api/public/project/1330/"},{"id":63969007,"basename":"e2ba9bd8-d2ea-11ed-99e8-0242ac140003.json","created":"2023-04-04T13:19:51.399031Z","datatypes":[],"download_url":"https://www.openhumans.org/data-management/datafile-download/63969007/?key=851fe98f-9d29-475d-ac05-5b6428e25309","metadata":{"data":{"drug":false,"abuse":false,"other":"Topic","negbody":false,"research":false,"viewable":false,"violence":false,"mentalhealth":false,"moderation_status":"not
+        reviewed"},"tags":["not public","non-research","Other triggering label"],"uuid":"e2ba9bd8-d2ea-11ed-99e8-0242ac140003","timestamp":"2023-04-04
+        13:19:50.571267","description":"Title text"},"source":"direct-sharing-1330","source_project":"https://www.openhumans.org/api/public/project/1330/"}]}'
+    headers:
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - max-age=0, no-cache, no-store, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3120'
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 04 Apr 2023 13:25:08 GMT
+      Expires:
+      - Tue, 04 Apr 2023 13:25:08 GMT
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Accept, Authorization, Cookie, Origin
+      Via:
+      - 1.1 vegur
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://www.openhumans.org/data-management/datafile-download/63969007/?key=851fe98f-9d29-475d-ac05-5b6428e25309
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2023 13:25:08 GMT
+      Location:
+      - https://open-humans-production.s3.amazonaws.com/member-files/direct-sharing-1330/01234567-89ab-cdef-0123-456789abcdef/01234567-89ab-cdef-0123-456789abcdef.json?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=43gw66thjfgdget34DFe1b%2F5G6FDd7H%3D&Expires=1680617915&x-oh-key=01234567-89ab-cdef-0123-456789abcdef
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Authorization, Cookie
+      Via:
+      - 1.1 vegur
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://open-humans-production.s3.amazonaws.com/member-files/direct-sharing-1330/01234567-89ab-cdef-0123-456789abcdef/01234567-89ab-cdef-0123-456789abcdef.json?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=43gw66thjfgdget34DFe1b%2F5G6FDd7H%3D&Expires=1680617915&x-oh-key=01234567-89ab-cdef-0123-456789abcdef
+  response:
+    body:
+      string: '{"data": {"experience_text": "Experience text", "difference_text":
+        "Difference text", "title_text": "Title text", "abuse": false, "violence":
+        false, "drug": false, "mentalhealth": false, "negbody": false, "other": "Topic",
+        "viewable": false, "research": false, "moderation_status": "not reviewed"},
+        "timestamp": "2023-04-04 13:19:50.571267"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '341'
+      Content-Type:
+      - binary/octet-stream
+      Date:
+      - Tue, 04 Apr 2023 13:25:10 GMT
+      Last-Modified:
+      - Tue, 04 Apr 2023 13:19:52 GMT
+      Server:
+      - AmazonS3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/server/apps/main/tests/fixtures/get_oh_file.yaml
+++ b/server/apps/main/tests/fixtures/get_oh_file.yaml
@@ -1,0 +1,76 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://www.openhumans.org/data-management/datafile-download/63968911/?key=8859abff-0967-4a0d-8196-cbda2dc8224f
+  response:
+    body:
+      string: ''
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/html; charset=utf-8
+      Date:
+      - Tue, 04 Apr 2023 13:18:35 GMT
+      Location:
+      - https://open-humans-production.s3.amazonaws.com/member-files/direct-sharing-1330/01234567-89ab-cdef-0123-456789abcdef/01234567-89ab-cdef-0123-456789abcdef.json?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=43gw66thjfgdget34DFe1b%2F5G6FDd7H%3D&Expires=1680617915&x-oh-key=01234567-89ab-cdef-0123-456789abcdef
+      Server:
+      - gunicorn/20.0.4
+      Vary:
+      - Authorization, Cookie
+      Via:
+      - 1.1 vegur
+      X-Frame-Options:
+      - SAMEORIGIN
+    status:
+      code: 302
+      message: Found
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.25.1
+    method: GET
+    uri: https://open-humans-production.s3.amazonaws.com/member-files/direct-sharing-1330/01234567-89ab-cdef-0123-456789abcdef/01234567-89ab-cdef-0123-456789abcdef.json?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=43gw66thjfgdget34DFe1b%2F5G6FDd7H%3D&Expires=1680617915&x-oh-key=01234567-89ab-cdef-0123-456789abcdef
+  response:
+    body:
+      string: '{"data": {"experience_text": "Experience text", "difference_text":
+        "Difference text", "title_text": "Title text", "abuse": false, "violence":
+        false, "drug": false, "mentalhealth": false, "negbody": false, "other": "Topic",
+        "viewable": false, "research": false, "moderation_status": "not reviewed"},
+        "timestamp": "2023-04-04 13:16:18.647417"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Content-Length:
+      - '341'
+      Content-Type:
+      - binary/octet-stream
+      Date:
+      - Tue, 04 Apr 2023 13:18:36 GMT
+      Last-Modified:
+      - Tue, 04 Apr 2023 13:16:20 GMT
+      Server:
+      - AmazonS3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/server/apps/main/tests/test_helpers.py
+++ b/server/apps/main/tests/test_helpers.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 import json
 from django.contrib.auth.models import Group
 from server.apps.main.helpers import reformat_date_string, get_review_status, \
-    is_moderator, get_oh_file, make_tags, extract_experience_details, delete_single_file_and_pe, delete_PE, \
+    is_moderator, get_oh_metadata, make_tags, extract_experience_details, delete_single_file_and_pe, delete_PE, \
     model_to_form, process_trigger_warnings, update_public_experience_db
     
 
@@ -67,13 +67,13 @@ class StoryHelper(TestCase):
 
     @vcr.use_cassette('server/apps/main/tests/fixtures/my_stories.yaml',
                       record_mode='none', filter_query_parameters=['access_token'])
-    def test_fetch_by_uuid_sucesss(self):
+    def test_fetch_by_uuid_successs(self):
         """
         Test that fetching an OH file by UUID works. 
         Should succeed if no duplicate UUID in account
         """
         target_uuid = "ebad2890-bc43-11ed-95a4-0242ac130003"
-        response = get_oh_file(self.moderator_user, target_uuid)
+        response = get_oh_metadata(self.moderator_user, target_uuid)
         self.assertEqual(response['id'], 63199447)
 
 
@@ -86,8 +86,7 @@ class StoryHelper(TestCase):
         """
         target_uuid = "ebad2890-bc43-11ed-95a4-0242ac130003"
         with self.assertRaises(Exception): 
-            get_oh_file(self.moderator_user, target_uuid)
-
+            get_oh_metadata(self.moderator_user, target_uuid)
 
     def test_make_tags(self):
         """
@@ -99,15 +98,17 @@ class StoryHelper(TestCase):
                     'drug': False, 'mentalhealth': False,'negbody': True,
                     'other': '',
                     'moderation_status': 'approved',
-                    'moderation_comments': ''
+                    'moderation_comments': '',
+                    'viewable': False,
+                    'research': False,
                     }
         returned_data = make_tags(tag_data)
-        self.assertIn('abuse',returned_data)
-        self.assertIn('negative body', returned_data)
+        self.assertNotIn('abuse',returned_data)
+        self.assertNotIn('negative body', returned_data)
         self.assertNotIn('mental health', returned_data)
-        self.assertEqual(len(returned_data), 3)
-        
-
+        self.assertIn('not public',returned_data)
+        self.assertIn('non-research',returned_data)
+        self.assertEqual(len(returned_data), 2)
 
     def test_extract_experience_details(self):
         """

--- a/server/apps/main/tests/test_helpers.py
+++ b/server/apps/main/tests/test_helpers.py
@@ -2,8 +2,9 @@ from django.test import TestCase
 import json
 from django.contrib.auth.models import Group
 from server.apps.main.helpers import reformat_date_string, get_review_status, \
-    is_moderator, get_oh_metadata, make_tags, extract_experience_details, delete_single_file_and_pe, delete_PE, \
-    model_to_form, process_trigger_warnings, update_public_experience_db
+    is_moderator, make_tags, extract_experience_details, delete_single_file_and_pe, delete_PE, \
+    model_to_form, process_trigger_warnings, update_public_experience_db, \
+    get_oh_metadata, get_oh_file, get_oh_combined
     
 
 from openhumans.models import OpenHumansMember 
@@ -87,6 +88,52 @@ class StoryHelper(TestCase):
         target_uuid = "ebad2890-bc43-11ed-95a4-0242ac130003"
         with self.assertRaises(Exception): 
             get_oh_metadata(self.moderator_user, target_uuid)
+
+    @vcr.use_cassette('server/apps/main/tests/fixtures/get_oh_file.yaml',
+                      record_mode='none', filter_query_parameters=['access_token'])
+    def test_fetch_oh_file(self):
+        """
+        Test that fetching an OH file.
+        """
+        target_url = "https://www.openhumans.org/data-management/datafile-download/63968911/?key=8859abff-0967-4a0d-8196-cbda2dc8224f"
+        response = get_oh_file(target_url)
+        self.assertIn("data", response)
+        self.assertEqual(response["data"]["experience_text"],"Experience text")
+        self.assertEqual(response["data"]["difference_text"],"Difference text")
+        self.assertEqual(response["data"]["title_text"],"Title text")
+        self.assertEqual(response["data"].get("description"),None)
+        self.assertEqual(response["data"].get("research"),False)
+        self.assertEqual(response["data"].get("viewable"),False)
+        self.assertNotIn("tags", response)
+        self.assertNotIn("metadata", response)
+
+    @vcr.use_cassette('server/apps/main/tests/fixtures/get_oh_combined.yaml',
+                      record_mode='none', filter_query_parameters=['access_token'])
+    def test_fetch_oh_combined(self):
+        """
+        Test that fetching an OH file in combined form works.
+        """
+        target_uuid = "e2ba9bd8-d2ea-11ed-99e8-0242ac140003"
+        response = get_oh_combined(self.moderator_user, target_uuid)
+        # Content extracted from the file
+        self.assertEqual(response["experience_text"],"Experience text")
+        self.assertEqual(response["difference_text"],"Difference text")
+        self.assertEqual(response["title_text"],"Title text")
+        # Content extracted from the metadata
+        self.assertEqual(response["research"],False)
+        self.assertEqual(response["viewable"],False)
+        self.assertEqual(response["moderation_status"],"not reviewed")
+        self.assertEqual(response["drug"],False)
+        self.assertEqual(response["abuse"],False)
+        self.assertEqual(response["negbody"],False)
+        self.assertEqual(response["violence"],False)
+        self.assertEqual(response["mentalhealth"],False)
+        self.assertEqual(response["other"],"Topic")
+        # Content that shouldn't be present
+        self.assertNotIn("descriptions", response)
+        self.assertNotIn("tags", response)
+        self.assertNotIn("metadata", response)
+        self.assertNotIn("data", response)
 
     def test_make_tags(self):
         """

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -20,9 +20,10 @@ from .helpers import (
     extract_experience_details,
     reformat_date_string,
     get_review_status,
-    get_oh_file,
+    get_oh_combined,
     delete_single_file_and_pe,
     upload,
+    rebuild_experience_data,
     make_uuid,
     delete_PE,
     update_public_experience_db,
@@ -141,8 +142,8 @@ def share_experience(request, uuid=False):
 
             if uuid:
                 # return data from oh.
-                data = get_oh_file(ohmember=request.user.openhumansmember, uuid=uuid)
-                form = ShareExperienceForm(data["metadata"]["data"])
+                data = get_oh_combined(ohmember=request.user.openhumansmember, uuid=uuid)
+                form = ShareExperienceForm(data)
                 title = "Edit experience"
 
             else:
@@ -165,8 +166,8 @@ def view_experience(request, uuid):
     """
     if request.user.is_authenticated:
         # return data from oh.
-        data = get_oh_file(ohmember=request.user.openhumansmember, uuid=uuid)
-        form = ShareExperienceForm(data["metadata"]["data"], disable_all=True)
+        data = get_oh_combined(ohmember=request.user.openhumansmember, uuid=uuid)
+        form = ShareExperienceForm(data, disable_all=True)
         return render(
             request,
             "main/share_experiences.html",
@@ -275,7 +276,7 @@ def moderate_public_experiences(request):
 # @vcr.use_cassette('tmp/my_stories.yaml', filter_query_parameters=['access_token'])
 def my_stories(request):
     """
-    List all stories that are associated with the OpenHumans proejct page.
+    List all stories that are associated with the OpenHumans project page.
     Including those which are not-shareable on the website
     """
     if request.user.is_authenticated:

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -214,3 +214,16 @@ FEATURE_POLICY: Dict[str, Union[str, List[str]]] = {}  # noqa: WPS234
 # https://docs.djangoproject.com/en/2.2/ref/settings/#std:setting-EMAIL_TIMEOUT
 
 EMAIL_TIMEOUT = 5
+
+# OpenHumans interaction
+# The maximum length allowed by OpenHumans for the descripition field
+DESCRIPTION_LEN_MAX = 100
+
+# The following items will be stripped from the metadata dictionary before
+# uploading to OpenHumans, since it's stored in the uploaded file itself
+METADATA_MASK = [
+    "experience_text",
+    "difference_text",
+    "title_text"
+]
+


### PR DESCRIPTION
Fixes #468.

There was considerable overlap between the metadata and the file contents stored on OpenHuman. This change streamlines the metadata to remove the descriptive text. The descriptive text is now retrieved by downloading the file from OpenHuman instead.