### PR TITLE
Add Code of Conduct initial content

### DIFF
--- a/server/apps/main/templates/main/code_of_conduct.html
+++ b/server/apps/main/templates/main/code_of_conduct.html
@@ -4,7 +4,7 @@
 
 {% block body_attributes%} data-spy="scroll" data-target="#content-bar" {% endblock %}
 
-  {% block content %}
+{% block content %}
 
 <!--Contents-->
 <section id="content">
@@ -14,31 +14,241 @@
         <div class="list-group col-lg-3 cotent-list" id="content-bar">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#placeholder_1">Placeholder 1<span class="badge badge-pill"></span></a>
+              href="#code-of-conduct">Code of Conduct<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#placeholder_2">Placeholder 2<span class="badge badge-pill"></span></a>
+              href="#purpose">What the Platform Is (and Isn't) For<span class="badge badge-pill"></span></a>
+          <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#acceptable-content">What Is and Isn't Acceptable to Mention in Stories<span class="badge badge-pill"></span></a>
+          <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#writing-for-others">Additional Guidelines for Writing on Behalf of Others<<span class="badge badge-pill"></span></a>
+          <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#responding-to-others">Responding to Others' Stories<span class="badge badge-pill"></span></a>
+          <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#reporting-breaches">How to Report Breaches of Code of Conduct and Safeguarding<<span class="badge badge-pill"></span></a>
         </div>
       </div>
 
+      <div class="topic-content col-9" data-offset="0" data-target="#content-bar"
+           style="padding: 2% 8%">
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="code-of-conduct"><em></em>Code of Conduct</h5>
 
-    <div class="topic-content col-9" data-offset="0" data-target="#content-bar"
-         style="padding: 2% 8%">
-      <div class="placeholder-1-class">
-        <h5 class="text-info" id="placeholder_1"><em></em>Title for placeholder 1</h5>
-        <p>Lorem ipsum</p>
+          <p>The AutSPACEs platform is an online space which puts autistic people first. We are committed to providing a
+          safe and welcoming place for autistic people and their supporters to share experiences, knowing their voices will
+          be heard and their contributions recognised.</p>
 
-        <p>Two households both alike in dignity, in fair Verona where we lay our scene. I can't remember the rest. Something about civil blood
-          and civil hands being unclean?</p>
+          <p>AutSPACEs allows users to share stories publicly with other users as well as privately with researchers. In
+          order for the platform to be a respectful and welcoming place for autistic people and other members of the
+          community, everyone sharing a story publicly will be required to follow this code of conduct. Before they are
+          published all stories will be reviewed by a moderator who will use this document as guidance when making decisions
+          as to whether a post can be approved or not.</p>
+
+          <p>This code of conduct exists for clarity and fairness, as well as to ensure the values of AutSPACEs are upheld.
+          It was co-written by autistic people, the parents and carers of autistic people, and researchers with expertise in
+          creating inclusive online spaces.</p>
+
+          <p>The lead investigator of AutSPACEs &mdash; Dr. Bastian Greshake Tzovaras &mdash; is responsible for enforcing
+          the Code of Conduct and overseeing the moderation process. She can be contacted by emailing <a
+          href="mailto:bgreshaketzovaras@turing.ac.uk">bgreshaketzovaras@turing.ac.uk</a>. Reports may be reviewed by other
+          members of the research team, unless there is a conflict of interest, and will be kept confidential.</p>
+
+        </div>
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="purpose"><em></em>What the Platform Is (and Isn't) For</h5>
+
+          <p>The primary purpose of the platform is to gather data about sensory processing and navigating environments in
+          order to make the world more accessible to autistic people. In order for a story to be approved by moderators it
+          must be relevant to this. This doesn’t mean you can’t write about other things, as long as they relate to sensory
+          experiences. The data we are collecting is also for a specific demographic: all stories must be about experiences
+          of someone who is over the age of 18 at the time of posting. Entries about the past before the user was 18 are
+          permitted. For instance, an 18 year old could post about an experience they had when they were 10, but a 10
+          year-old would not be permitted to post.</p>
+
+          <p>As this is a data collection platform, users will have the option to share their stories with both researchers
+          and/or the public. Further information about how stories will be used by researchers is available [insert link].
+          Only stories posted to the public will be moderated, all information below.</p>
+
+          <p>As much as we would like to be able to help everyone with everything, that is unfortunately out of the scope of
+          this project. AutSPACEs cannot offer professional support, however, we can link you to appropriate sources if
+          necessary.</p>
+
+          <div class="callout">
+            <h6 class="guideline-header" id="">What is considered to be sensory?</h6>
+            <div class="card-body">
+
+            <p>People with autism often have sensory differences. This means their senses may be weaker or stronger than
+            those who are neurotypical. This is why navigating and coping in the world can be very difficult for people with
+            autism.</p>
+
+            <p>There are seven senses:</p>
+
+            <ul>
+              <li>Sight</li>
+              <li>Hearing</li>
+              <li>Smell</li>
+              <li>Taste</li>
+              <li>Touch</li>
+              <li>Balance (Vestibular)</li>
+              <li>Body Awareness (Proprioception)</li>
+            </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="acceptable-content"><em></em>What Is and Isn't Acceptable to Mention in Stories</h5>
+
+            <p>AutSPACEs is designed to be a welcoming and safe place for all people with autism to share and read
+            experiences. In order to ensure this we have created a <span class="word-red">Red</span> and <span
+            class="word-amber">Amber</span> list of words and topics that may be offensive or triggering to some users.</p>
+
+            <p>The purpose of having the <span class="word-red">Red</span> category is to make sure we don’t publish
+            experiences which contravene our values of mutual respect, diversity, and inclusion, or which cause a risk to
+            the person who posts the experience or others. Examples of content marked <span class="word-red">Red</span>
+            would be direct or indirect attacks on people for being autistic, referring to autism as a dysfunction, using an
+            offensive or prejudicial term to describe someone. Explicitly including someone’s identity or sensitive data is
+            strictly forbidden, examples of sensitive data are listed below.</p>
+
+            <div class="callout callout-red">
+              <ul>
+                <li>A person’s first name and/or surname</li>
+                <li>Someone’s contact details including:  address, phone number, school, email address or place of work</li>
+                <li>Anything that could distinguish that person from others (e.g. hair colour or skin tone)</li>
+              </ul>
+            </div>
+
+            <p>The purpose of having the <span class="word-amber">Amber</span> list is to help users identify posts that
+            they may find triggering or distressing before they read them, to avoid harm to users of AutSPACEs. While some
+            people may be sensitive to them, it is important that these experiences are available, and that users are free
+            to express themselves. Examples of content marked <span class="word-amber">Amber</span> might be an account of
+            bullying, a traumatic home environment, or descriptions of verbal abuse which a user has experienced.</p>
+
+            <p>Stories that include <span class="word-red">Red</span> content will automatically be disapproved. Those
+            regarded as <span class="word-amber">Amber</span> will be approved but may be labelled as ‘triggering’ when
+            posted on the platform.</p>
+
+            <p>Any post which discriminates or belittles anyone based on the below categories will be regarded as <span
+            class="word-red">Red</span>.</p>
+
+            <div class="callout callout-red">
+              <ul>
+                <li>Neurodiversity</li>
+                <li>Gender Identity and/or Expression</li>
+                <li>Sexual Orientation</li>
+                <li>Disability and/or Health</li>
+                <li>Physical Appearance (e.g. skin colour, body size, etc.)</li>
+                <li>Nationality, Citizenship and Ethnic or Social Origin</li>
+                <li>Religion/Belief (or lack thereof)</li>
+                <li>Pregnancy and/or Familial Status</li>
+                <li>Veteran Status</li>
+                <li>Genetic Information</li>
+                <li>Property and/or Socio-Economic Status</li>
+                <li>Technical Preferences</li>
+                <li>Experience Level</li>
+              </ul>
+            </div>
+
+            <p>All racial slurs [insert link to external list of racial slurs] will automatically be considered <span
+            class="word-red">Red</span> whether they are direct or indirect comments. Swear words and disability slurs will
+            be rated <span class="word-amber">Amber</span>.</p>
+
+            <p>Below is a list of topics that may be triggering to some users. All stories that refer to these topics will
+            be listed as <span class="word-amber">Amber</span>.</p>
+
+            <div class="callout callout-amber">
+              <ul>
+                <li>Abuse (physical, sexual, emotional and verbal)</li>
+                <li>Violence and Assault</li>
+                <li>Drug and/or Alcohol use</li>
+                <li>Mental Health Issues</li>
+                <li>Negative body image</li>
+              </ul>
+            </div>
+        </div>
+
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="writing-for-others"><em></em>Additional Guidelines for Writing on Behalf of Others</h5>
+
+          <p>While AutSPACEs exists as a platform where autistic people can share their own stories, we are aware that there
+          will be some cases where autistic people will need support to use the platform or may require others to share
+          experiences on their behalf. All of the above rules are still in place when posting on behalf of others, and
+          anything which breaks them will be automatically disapproved for publication on the AutSPACEs platform.</p>
+
+          <p>These are a series of questions to prompt you to think about how you can best share a story that is not your
+          own, in order to make sure the story is respectful, appropriate, and representative.</p>
+
+          <h6 class="guideline-header" id="can-they-share-with-support">Can the person who you are writing about share their
+          own story with support?</h6>
+
+          <p>If so, please support them to share their own experience, rather than writing about their experience yourself
+          on their behalf. For instance, if they can speak but not write, it is better to allow them to dictate, and try to
+          write what they are saying as accurately as possible, than to write your own version of their story. It is also a
+          good idea to show what you wish to share to the person who you are writing on behalf of. If you can, try to find
+          out if this reflects their experience and if you can change it to make it better.</p>
+
+          <h6 class="guideline-header" id="have-they-consented">Have they consented to you writing on their behalf?</h6>
+
+          <p>If so, that’s great. If not, please seek their consent. If they do not give their consent, do not share their
+          story, even if you think it would benefit them if it is shared. If they are not able to meaningfully consent, then
+          please share only if you think that it is in their best interests to do so.</p>
+
+          <h6 class="guideline-header" id="are-you-the-right-person">Are you the right person to share this story?</h6>
+
+          <p>If there is someone else who has a closer personal connection to the person whose story you would like to be
+          shared on the platform, or who is better qualified to so, consider asking them to share the story instead. You may
+          also wish to share your version of the story with others who know the person well to make it more accurate.</p>
+
+          <h6 class="guideline-header" id="are-you-making-assumptions">Are you making any assumptions or inferences about
+          the autistic person you are sharing on behalf of?</h6>
+
+          <p>It is very natural to think we know what is going on in other people’s minds, and sometimes we can talk about
+          this as a fact without even noticing we are doing so. These are not facts but inferences. It is better to stick to
+          telling us what you observed about the autistic person you are writing on behalf of rather than making assumptions
+          about what they think or feel.</p>
+
+          <p>E.g. don’t write, <i>“my autistic daughter was stressed because the train was loud’</i>,</p>
+
+          <p>Please write, <i>‘My autistic daughter shouted and covered his ears when a train passed him loudly. This
+          happens frequently.’’</i></p>
+
+          <p>The aim of entering on behalf of others should be in the service of autistic people’s wellbeing. If you need
+          more support as a carer or parent, we recommend these resources: [link to resources?]</p>
+
+          <h6 class="guideline-header" id="are-you-adding-subjective-detail">Are you adding subjective and personal details
+          which are your own?</h6>
+
+          <p>It is better to write neutrally about the things you are observing. Focus on the experience of the autistic
+          person you are writing on behalf of. Don’t focus on your own experiences or the experiences of other people,
+          except when it is relevant to the autistic person’s experience. In particular, do not use this space for venting
+          or complaining about autistic people.</p>
+
+          <p>E.g. don’t write, <i>“I hate it when my autistic son makes a scene in the supermarket, it’s so
+          embarrassing”</i>,</p>
+
+          <p>Please write, <i>“my autistic son cried and stood still in a busy supermarket. Some people around us showed
+          negative expressions and body language while this happened. This usually occurs when we go to the
+          supermarket.”</i></p> </div>
+
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="responding-to-others"><em></em>Responding to Others' Stories</h5>
+
+          <p>AutSPACEs is designed to be a safe space where people can post their experiences without the fear of receiving
+          negative or upsetting responses. In order to maintain this safety there is no comment section on the site. Any
+          stories posted as a direct response to another post will be disapproved.</p>
+
+          <p>However, as AutSPACEs is an anonymous platform, it is permissible to discuss stories on other sites.</p>
+        </div>
+
+        <div class="code-of-conduct">
+          <h5 class="text-info" id="reporting-breaches"><em></em>How to Report Breaches of Code of Conduct and
+          Safeguarding</h5>
+
+          <p>TBC</p>
+        </div>
 
       </div>
-      <div class="placeholder-2-class">
-        <h5 class="text-info" id="placeholder_2"><em></em>Title for placeholder 2</h5>
-        <p>The quick brown fox jumps over the lazy dog.</p>
-
-       </div>
-     </div>
+    </div>
   </div>
-</div>
 
 </section>
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -482,5 +482,49 @@ body {
 .registration-text {
   line-height: 2;
   font-size: 20px;
-
 }
+
+/* CODE OF CONDUCT */
+
+.word-red {
+  color: #cc0000;
+}
+
+.word-amber {
+  color: #e69138;
+}
+
+.callout {
+  padding: 1.25rem;
+  margin-top: 1.25rem;
+  margin-bottom: 1.25rem;
+  border: 1px solid #e9ecef;
+  border-left-width: .25rem;
+  border-radius: .25rem
+}
+
+.callout h5 {
+  margin-bottom: .25rem
+}
+
+.callout p:last-child {
+  margin-bottom: 0
+}
+
+.callout+.callout {
+  margin-top: -.25rem
+}
+
+.callout-red {
+  border-left-color: #cc0000
+}
+
+.callout-amber {
+  border-left-color: #e69138;
+}
+
+.guideline-header {
+  font-weight: bold;
+  color: #17a2b8;
+}
+


### PR DESCRIPTION
Adds initial (not-yet-complete) text for the Code of Conduct page.

Contributes to #460.

The text used for this is from the [Code of Conduct copy doc](https://docs.google.com/document/d/1qhBlUxMVv8F_QGuY1re2xbLLZ-mNmak4TISmC-nFW58/edit#).