### PR TITLE
Add warning popup when editing resets the moderation pipeline.

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -41,7 +41,9 @@ class ShareExperienceForm(forms.Form):
     other.group = 2
 
     # sharing options
-    viewable = forms.BooleanField(label = "Share on AutSPACE website", required=False)
+    viewable = forms.BooleanField(label = "Share on AutSPACE website", 
+                                  required=False,
+                                  widget=forms.CheckboxInput(attrs={'id':'shareOnAutSPACEs'}))
     viewable.group = 3
     research = forms.BooleanField(label = "Share for research", required=False)
     research.group = 3

--- a/server/apps/main/templates/main/application.html
+++ b/server/apps/main/templates/main/application.html
@@ -6,6 +6,9 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <title>{% block title %}AutSPACEs{% endblock %}</title>
 
+    <!-- jQuery -->
+    {% include 'main/partials/jquery.html' %}
+    
     <!-- Bootstrap CSS -->
 
 
@@ -48,7 +51,6 @@
       {% include 'main/partials/footer.html'%}
     </section>
 
-    {% include 'main/partials/jquery.html' %}
     <script src="{% static '/js/main.js' %}"></script>
 
   </body>

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -252,5 +252,5 @@
 
   <script src="{% static 'js/submit-warning.js' %}"></script>
 
-  {% endblock %}
+{% endblock %}
 

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -218,13 +218,39 @@
     </div>
     {% else %}
       <div class='form-group'>
-        <input type="submit" class="btn btn-outline-dark btn-lg float-right" value="Submit">
+        <!-- Add an id and data attributes to the submit button -->
+          <button type="button" class="btn btn-outline-dark btn-lg float-right" id="submitBtn" 
+          data-uuid="{{ uuid }}" data-moderation-status="{{ moderation_status }}">Submit</button>
       </div>
     </form>
   </div>
     {% endif %}
 
 
-</section>
+  </section>
 
-{% endblock %}
+  <!-- Modal for the submit button -->
+  <div class="modal fade" id="submitModal" tabindex="-1" role="dialog" aria-labelledby="submitModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="submitModalLabel">Confirmation</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+          Submitting your edited story will send it for moderation again. Do you want to proceed?
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="submitForm">Submit</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="{% static 'js/submit-warning.js' %}"></script>
+
+  {% endblock %}
+

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -151,15 +151,20 @@ def share_experience(request, uuid=False):
                 data = get_oh_combined(ohmember=request.user.openhumansmember, uuid=uuid)
                 form = ShareExperienceForm(data)
                 title = "Edit experience"
+                viewable = data["metadata"]["data"].get("viewable", False)
+                moderation_status = data["metadata"]["data"].get("moderation_status", "not reviewed")
 
             else:
                 form = ShareExperienceForm()
                 title = "Share experience"
+                viewable = False
+                moderation_status = "not reviewed"
 
             return render(
                 request,
                 "main/share_experiences.html",
-                {"form": form, "uuid": uuid, "title": title},
+                {"form": form, "uuid": uuid, "title": title,
+                 "viewable": viewable, "moderation_status": moderation_status}
             )
 
     else:

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -151,9 +151,8 @@ def share_experience(request, uuid=False):
                 data = get_oh_combined(ohmember=request.user.openhumansmember, uuid=uuid)
                 form = ShareExperienceForm(data)
                 title = "Edit experience"
-                viewable = data["metadata"]["data"].get("viewable", False)
-                moderation_status = data["metadata"]["data"].get("moderation_status", "not reviewed")
-
+                viewable = data.get("viewable", False)
+                moderation_status = data.get("moderation_status", "not reviewed")
             else:
                 form = ShareExperienceForm()
                 title = "Share experience"

--- a/static/js/submit-warning.js
+++ b/static/js/submit-warning.js
@@ -1,0 +1,53 @@
+document.addEventListener('DOMContentLoaded', function () {
+  let form = document.querySelector('.form-context');
+  let submitFormButton = document.getElementById('submitForm');
+  let viewableCheckbox = document.getElementById('shareOnAutSPACEs');
+  
+  // Check that event listener is working
+  // if (viewableCheckbox) {
+  //   viewableCheckbox.addEventListener('change', function () {
+  //     console.log('viewableCheckbox checked:', viewableCheckbox.checked);
+  //   });
+  // }
+  
+  if (submitFormButton) {
+    let submitModal = new bootstrap.Modal(document.getElementById('submitModal'));
+
+    // Check whether Share Experience checkbox is ticked
+    let shareExperience = () => {
+      return viewableCheckbox.checked;
+    };
+
+    let submitButton = document.getElementById('submitBtn');
+    if (submitButton) {
+      // when submit button is clicked, check if the Share Experience checkbox is ticked,
+      // and the story exists (uuid) and has been moderated (approved)
+      submitButton.addEventListener('click', (event) => {
+        const uuid = submitButton.getAttribute('data-uuid');
+        const moderation_status = submitButton.getAttribute('data-moderation-status');
+        const shouldShowModal = uuid && moderation_status === 'approved';
+
+        if (shareExperience() && shouldShowModal) {
+          event.preventDefault(); // Prevent default button action
+          submitModal.show(); // Show the modal if conditions are met
+        } else {
+          form.submit(); // Submit the form if conditions are not met
+        }
+      });
+    }
+    
+    // When the submit button is clicked in the modal popup, submit the form
+    submitFormButton.addEventListener('click', function () {
+      submitModal.hide();
+      form.submit();
+    });
+  }
+});
+
+
+
+  
+  
+  
+  
+  

--- a/static/js/submit-warning.js
+++ b/static/js/submit-warning.js
@@ -1,47 +1,38 @@
-document.addEventListener('DOMContentLoaded', function () {
-  let form = document.querySelector('.form-context');
-  let submitFormButton = document.getElementById('submitForm');
-  let viewableCheckbox = document.getElementById('shareOnAutSPACEs');
-  
-  // Check that event listener is working
-  // if (viewableCheckbox) {
-  //   viewableCheckbox.addEventListener('change', function () {
-  //     console.log('viewableCheckbox checked:', viewableCheckbox.checked);
-  //   });
-  // }
-  
-  if (submitFormButton) {
-    let submitModal = new bootstrap.Modal(document.getElementById('submitModal'));
+$(document).ready(function () {
+  let form = $('.form-context');
+  let submitFormButton = $('#submitForm');
+  let viewableCheckbox = $('#shareOnAutSPACEs');
+ 
+  let submitModal = new bootstrap.Modal($('#submitModal').get(0));
 
-    // Check whether Share Experience checkbox is ticked
-    let shareExperience = () => {
-      return viewableCheckbox.checked;
-    };
+  // Check whether Share Experience checkbox is ticked
+  let shareExperience = () => {
+    return viewableCheckbox.prop('checked');
+  };
 
-    let submitButton = document.getElementById('submitBtn');
-    if (submitButton) {
-      // when submit button is clicked, check if the Share Experience checkbox is ticked,
-      // and the story exists (uuid) and has been moderated (approved)
-      submitButton.addEventListener('click', (event) => {
-        const uuid = submitButton.getAttribute('data-uuid');
-        const moderation_status = submitButton.getAttribute('data-moderation-status');
-        const shouldShowModal = uuid && moderation_status === 'approved';
+  let submitButton = $('#submitBtn');
+  // when submit button is clicked, check if the Share Experience checkbox is ticked,
+  // and the story exists (uuid) and has been moderated (approved)
+  submitButton.on('click', (event) => {
+    const uuid = submitButton.data('uuid');
+    const moderation_status = submitButton.data('moderation-status');
+    const shouldShowModal = uuid && moderation_status === 'approved';
 
-        if (shareExperience() && shouldShowModal) {
-          event.preventDefault(); // Prevent default button action
-          submitModal.show(); // Show the modal if conditions are met
-        } else {
-          form.submit(); // Submit the form if conditions are not met
-        }
-      });
+    if (shareExperience() && shouldShowModal) {
+      event.preventDefault(); // Prevent default button action
+      submitModal.show(); // Show the modal if conditions are met
+    } else {
+      form.submit(); // Submit the form if conditions are not met
     }
-    
-    // When the submit button is clicked in the modal popup, submit the form
-    submitFormButton.addEventListener('click', function () {
-      submitModal.hide();
-      form.submit();
-    });
-  }
+  });
+  
+  
+  // When the submit button is clicked in the modal popup, submit the form
+  submitFormButton.on('click', function () {
+    submitModal.hide();
+    form.submit();
+  });
+  
 });
 
 


### PR DESCRIPTION
* Adds warning popup modal when viewable stories get edited again.   
* Tracks the "Share on AutSPACE website" tickbox, so that unchecking the box during editing prevents the popup from showing up (as there won't be a second moderation). 

Issue #433 

