### PR TITLE
Restructure moderation pages

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -118,6 +118,9 @@ class ModerateExperienceForm(forms.Form):
                                                               'class':'form-control'}))
     moderation_comments.group = "hidden"
 
+    moderation_prior = forms.CharField(widget=forms.HiddenInput())
+    moderation_prior.group = "hidden"
+
     def __init__(self, *args, **kwargs):
         """ Disable free text fields to the moderator, or disable all fields if in 'read only' mode"""
 

--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -6,6 +6,9 @@ import requests
 from django.contrib.auth.models import Group
 from django.forms.models import model_to_dict
 from django.conf import settings
+from django.core.paginator import Paginator
+from django.db.models import Q
+from django.shortcuts import redirect, render
 from .forms import ModerateExperienceForm
 from .models import PublicExperience, ExperienceHistory
 
@@ -23,6 +26,7 @@ def is_moderator(user):
 def model_to_form(model, disable_moderator=False):
     """Converts Model to form."""
     model_dict = model_to_dict(model)
+    model_dict["moderation_prior"] = model_dict["moderation_status"]
 
     form = ModerateExperienceForm(
         {**model_dict, "viewable": True},  # we only moderate public experiences
@@ -364,3 +368,73 @@ def update_public_experience_db(data, uuid, ohmember, editing_user, **change_inf
 
     else:
         delete_PE(uuid, ohmember)
+
+def moderate_page(request, status, experiences):
+    """
+    View containing lists of the given Public Experiences
+
+    A helper function for generating the Moderation pages.
+    """
+    # Check to see if a search has been performed
+    searched = request.GET.get("searched", False)
+
+    if searched:
+        # If there's a search term, additionally filter on it too
+        experiences = experiences.filter(
+            Q(title_text__icontains=searched)
+            | Q(experience_text__icontains=searched)
+            | Q(difference_text__icontains=searched)
+        )
+
+    paginator = Paginator(experiences, settings.EXPERIENCES_PER_PAGE)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+    page_obj.page_range = paginator.get_elided_page_range(page_obj.number, on_each_side=2, on_ends=1)
+    page_obj.offset = page_obj.start_index() - 1
+
+    unreviewed = PublicExperience.objects.filter(
+        Q(moderation_status="not reviewed")
+    ).count()
+    inreview = PublicExperience.objects.filter(
+        Q(moderation_status="in review")
+    ).count()
+    approved = PublicExperience.objects.filter(
+        Q(moderation_status="approved")
+    ).count()
+    rejected = PublicExperience.objects.filter(
+        Q(moderation_status="rejected")
+    ).count()
+
+    subtitle = {
+        "pending": "Experiences for Moderation",
+        "approved": "Approved Experiences",
+        "rejected": "Rejected Experiences",
+    }.get(status, "Moderation")
+
+    return render(
+        request,
+        "main/moderation_list.html",
+        context={
+            "subtitle": subtitle,
+            "status": status,
+            "page_obj": page_obj,
+            "unreviewed": unreviewed,
+            "inreview": inreview,
+            "approved": approved,
+            "rejected": rejected,
+            "searched": searched if searched else "",
+            "params": "?status=" + status + (("&searched=" + searched) if searched else ""),
+        },
+    )
+
+def choose_moderation_redirect(moderation_prior):
+    """
+    Selects an appropriate redirect from the moderate story form
+
+    When a moderator submits a story moderation, the form redirects
+    to different places depending on where the user requested the
+    moderation from. This helper function returns the place to
+    redurect to.
+    """
+    return moderation_prior if moderation_prior in ["approved", "rejected"] else "pending"
+

--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -183,14 +183,18 @@
 
     {% for group in field_groups %}
       {% if group.grouper == "hidden" %}
-        
+
           {% for field in group.list %}
+          {% if field.is_hidden %}
+          {{ field }}
+          {% else %}
           <div class="form-group">
             <h3><label for="{{ field.auto_id}}">{{ field.label }}</label></h3>
             {{ field }}
-           </div>
-           {% endfor %}
-        
+          </div>
+          {% endif %}
+          {% endfor %}
+
 
       {% else %}
         {% if group.grouper == 2 %}

--- a/server/apps/main/templates/main/moderation_list.html
+++ b/server/apps/main/templates/main/moderation_list.html
@@ -1,0 +1,130 @@
+{% extends 'main/application.html' %}
+
+{% block title %}AutSPACEs - Experiences for moderation {% endblock %}
+
+{% load static %}
+{% load custom_tags %}
+{% load humanize %}
+
+{% block content %}
+
+<section id="moderation-intro">
+  <div class="row">
+    <div class="col-lg-12">
+      <div class="card-header"><h4>Moderation Summary</h4></div>
+      <div class="card-body">
+        <!-- new_experiences = filter(lambda x: x.attr0 == attr0 and x.attr1 == attr1, lst) -->
+        <div class="row align-items-center" style="left: 0px">
+          <div class="col-lg-6">
+            <p>New Experiences on the Platform: {{ unreviewed }} </p>
+            <p>Under review: {{ inreview }} </p>
+          </div>
+          <div class="col-lg-6">
+            <p>Approved: {{ approved }} </p>
+            <p>Rejected: {{ rejected }} </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="card-header"><h4>{{ subtitle }}</h4></div>
+
+      <div class="card-body">
+        <div class="container search">
+          <form method="GET" action="{% url 'main:moderation_list' %}{{ params }}">
+            <div class="form-row align-items-center" style="left: 0px">
+              <div class="col-lg-10">
+                <label class="sr-only" for="inlineFormInput">Name</label>
+                <input class="form-control mb-2"
+                        id="inlineFormInput"
+                        placeholder="Search {{ status }} stories"
+                        type="text"
+                        name="searched"
+                        value="{{ searched }}"
+                        />
+              </div>
+
+              <div class="col-auto">
+                <button class="btn btn-primary mb-2" type="submit">Search Stories</button>
+              </div>
+            </div>
+          </form>
+        </div>
+
+        <table class="table table-responsive-lg table-hover table-striped" style="width:auto">
+          <thead><tr>
+            <th class="number-th" scope="col">Nr.</th>
+            <th class="title-th" scope="col">Title</th>
+            <th class="triggering-label" scope="col">Triggering Labels</th>
+            <th class="moderation-status" scope="col">Moderation Status</th>
+            <th class="title-th" scope="col">Moderate</th>
+            </tr></thead>
+            <tbody>
+              {% for experience in page_obj %}
+              <tr>
+                <th scope="row">{{ forloop.counter|add:page_obj.offset }}</th>
+                <td>{% firstof experience.title_text "notitle" %}</td>
+                <td>
+                  {% if experience.abuse or experience.violence or experience.drug or experience.mentalhealth or experience.negbody or experience.other %}
+                  <span class="badge badge-warning float-right" style="font-size: 1rem; margin-top:2%">
+                    Includes triggering contents
+                  </span>
+                  {% endif %}
+                </td>
+                <td>{{ experience.moderation_status }}</td>
+                <td>
+                  <a class="btn btn-primary" href="{% url 'main:moderate_exp' experience.experience_id %}">
+                    Moderate experience
+                  </a>
+              </td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+
+          <ul class="pagination justify-content-end">
+            {% if page_obj.has_previous %}
+            <li class="page-itemd">
+              <a class="page-link" href="{{ params }}&page={{ page_obj.previous_page_number }}">Previous</a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+              <a class="page-link" href="#" tabindex="-1">Previous</a>
+            </li>
+            {% endif %}
+
+            {% for page_number in page_obj.page_range %}
+
+            {% if page_obj.number == page_number %}
+            <li class="page-item active">
+              <a class="page-link" href="{{ params }}&page={{ page_number }}">{{ page_number}}</a>
+            </li>
+            {% elif page_number == page_obj.paginator.ELLIPSIS %}
+            <li class="page-item disabled">
+              <a class="page-link" href="#">&hellip;</a>
+            </li>
+            {% else %}
+            <li class="page-item">
+              <a class="page-link" href="{{ params }}&page={{ page_number }}">{{ page_number}}</a>
+            </li>
+            {% endif %}
+
+            {% endfor %}
+
+            {% if page_obj.has_next %}
+            <li class="page-item">
+              <a class="page-link" href="{{ params }}&page={{ page_obj.next_page_number }}">Next</a>
+            </li>
+            {% else %}
+            <li class="page-item disabled">
+              <a class="page-link" href="#" tabindex="-1">Next</a>
+            </li>
+            {% endif %}
+          </ul>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{% endblock %}

--- a/server/apps/main/templates/main/partials/navigation.html
+++ b/server/apps/main/templates/main/partials/navigation.html
@@ -26,12 +26,24 @@
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
               <a class="dropdown-item" href="{% url 'main:public_experiences' %}">View Stories</a>
               <a class="dropdown-item" href="{% url 'main:share_exp' %}">Share Stories</a>
-              {% is_moderator user as moderator %}
-              {% if moderator %}
               <a class="dropdown-item" href="{% url 'main:moderate_public_experiences' %}">Moderate</a>
-              {% endif %}
             </div>
           </li>
+          {% is_moderator user as moderator %}
+          {% if moderator %}
+          <li class="nav-item dropdown" style="padding: 0 0">
+            <a class="nav-link dropdown-toggle nav-content" href="#" id="navbarDropdownMenuLink" role="button"
+              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="padding: 0 25px">
+            Moderation
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+              <a class="dropdown-item" href="{% url 'main:moderation_list' %}?status=pending">Pending</a>
+              <a class="dropdown-item" href="{% url 'main:moderation_list' %}?status=approved">Approved</a>
+              <a class="dropdown-item" href="{% url 'main:moderation_list' %}?status=rejected">Rejected</a>
+            </div>
+          </li>
+
+          {% endif %}
           <li>
             <a class="nav-content nav-item nav-link" href="{% url 'main:my_stories' %}">My Stories</a>
           </li>

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -18,6 +18,7 @@ urlpatterns = [
         views.moderate_public_experiences,
         name="moderate_public_experiences",
     ),
+    re_path(r"moderation_list/?$", views.moderation_list, name="moderation_list"),
     path("delete/<uuid>/<title>/", views.delete_experience, name="delete_exp"),
     path("share_exp/", views.share_experience, name="share_exp"),
     path("edit/<uuid>/", views.share_experience, name="edit_exp"),

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth import logout
 from django.shortcuts import redirect, render
 from openhumans.models import OpenHumansMember
 from django.db.models import Q
+from django.urls import reverse
 
 from .models import PublicExperience
 
@@ -28,6 +29,8 @@ from .helpers import (
     delete_PE,
     update_public_experience_db,
     process_trigger_warnings,
+    moderate_page,
+    choose_moderation_redirect,
 )
 
 logger = logging.getLogger(__name__)
@@ -283,6 +286,42 @@ def moderate_public_experiences(request):
     else:
         return redirect("main:overview")
 
+def moderation_list(request):
+    """
+    View containing lists of Public Experiences with a given status
+
+    When status is "pending" this includes experiences marked as "unmoderated"
+    or "in review".
+
+    When status is "approved" it includes experiences marked as "approved".
+
+    When status is "rejected" it includes experiences marked as "rejected".
+    """
+    if request.user.is_authenticated and is_moderator(request.user):
+        status = request.GET.get("status", "pending")
+        if status not in ["pending", "approved", "rejected"]:
+            status = "pending"
+
+        if status == "approved":
+            # Search through approved experiences
+            experiences = PublicExperience.objects.filter(
+                moderation_status="approved"
+            ).order_by("created_at")
+        elif status == "rejected":
+            # Search through rejected experiences
+            experiences = PublicExperience.objects.filter(
+                moderation_status="rejected"
+            ).order_by("created_at")
+        else:
+            # Search through unreviewed or in review experiences
+            experiences = PublicExperience.objects.filter(
+                Q(moderation_status="not reviewed") | Q(moderation_status="in review")
+            ).order_by("created_at")
+
+        return moderate_page(request, status, experiences)
+    else:
+        return redirect("main:overview")
+
 # @vcr.use_cassette('tmp/my_stories.yaml', filter_query_parameters=['access_token'])
 def my_stories(request):
     """
@@ -317,6 +356,7 @@ def moderate_experience(request, uuid):
             data = {**unchanged_experience_details, **trigger_details}
 
             moderation_comments = data.pop("moderation_comments", None)
+            moderation_prior = data.pop("moderation_prior", "not moderated")
 
             # get the users OH member id from the model
             user_OH_member = model.open_humans_member
@@ -338,7 +378,8 @@ def moderate_experience(request, uuid):
                 # if user writing E has deauthorized autspaces, delete public experience
                 delete_PE(uuid=uuid, ohmember=user_OH_member)
             # redirect to a new URL:
-            return redirect("main:moderate_public_experiences")
+            status = choose_moderation_redirect(moderation_prior)
+            return redirect("{}?status={}".format(reverse("main:moderation_list"), status))
 
         else:
             experience_title = model.title_text

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -225,3 +225,7 @@ METADATA_MASK = [
     "title_text"
 ]
 
+# The number of experiences to show on the moderation pages
+EXPERIENCES_PER_PAGE = 10
+
+


### PR DESCRIPTION
Restructures the moderation pages:

1. Splits the moderation view into three pages: pending, approved and rejected
2. Adds pagination for each of the categories
3. Adds search functionality

Fixes #463.