### PR TITLE
fix button declarations

### DIFF
--- a/server/apps/main/templates/main/confirmation_page.html
+++ b/server/apps/main/templates/main/confirmation_page.html
@@ -47,21 +47,21 @@
         What would you like to do next ?
       </p>
 
-      <div class="btn-class btn-class-confirmationpage">
-        <a href="{% url 'main:share_exp' %}">
-          <button class="btn btn-outline-primary btn-lg btn-confirmationpage" type="button">Enter Another Experience</button>
+      <div class="btn-class-confirmationpage">
+        <a href="{% url 'main:share_exp' %}" class="btn btn-outline-primary btn-lg btn-confirmationpage">
+          Enter Another Experience
         </a>
 
-        <a href="{% url 'main:my_stories' %}">
-          <button class="btn btn-outline-primary btn-lg btn-confirmationpage" type="button">Go To My Stories</button>
+        <a href="{% url 'main:my_stories' %}" class="btn btn-outline-primary btn-lg btn-confirmationpage">
+          Go To My Stories
         </a>
 
-        <a href="{% url 'main:public_experiences' %}">
-          <button class="btn btn-outline-primary btn-lg btn-confirmationpage" type="button">View Other Stories</button>
+        <a href="{% url 'main:public_experiences' %}" class="btn btn-outline-primary btn-lg btn-confirmationpage">
+          View Other Stories
         </a>
 
-        <a href="{% url 'main:about_us' %}">
-          <button class="btn btn-outline-primary btn-lg btn-confirmationpage" type="button">Find Out More About AutSPACEs</button>
+        <a href="{% url 'main:about_us' %}" class="btn btn-outline-primary btn-lg btn-confirmationpage">
+          Find Out More About AutSPACEs
         </a>
 
       </div>

--- a/server/apps/main/templates/main/deletion_success.html
+++ b/server/apps/main/templates/main/deletion_success.html
@@ -21,20 +21,20 @@
       </p>
 
       <div class="btn-class">
-        <a href="{% url 'main:share_exp' %}">
-          <button class="btn btn-outline-primary btn-lg" type="button">Enter Another Experience</button>
+        <a href="{% url 'main:share_exp' %}" class="btn btn-outline-primary btn-lg" type="button">
+          Enter Another Experience
         </a>
 
-        <a href="{% url 'main:my_stories' %}">
-          <button class="btn btn-outline-primary btn-lg" type="button">Go To My Stories</button>
+        <a href="{% url 'main:my_stories' %}" class="btn btn-outline-primary btn-lg" type="button">
+          Go To My Stories
         </a>
 
-        <a href="{% url 'main:public_experiences' %}">
-          <button class="btn btn-outline-primary btn-lg" type="button">View Other Stories</button>
+        <a href="{% url 'main:public_experiences' %}" class="btn btn-outline-primary btn-lg" type="button">
+          View Other Stories
         </a>
 
-        <a href="{% url 'main:about_us' %}">
-          <button class="btn btn-outline-primary btn-lg" type="button">Find Out More About AutSPACEs</button>
+        <a href="{% url 'main:about_us' %}" class="btn btn-outline-primary btn-lg" type="button">
+          Find Out More About AutSPACEs
         </a>
 
       </div>


### PR DESCRIPTION
On the post-experience-submission confirmation page there's a number of buttons for next steps. These were somehow weirdly nested between `<a href>` and `<button>` stylings, making them appear slightly strange and less accessible through keyboard navigation (e.g. via `vimium`). 

I've just gone ahead and fixed it :D