### PR TITLE
Clean experience submission view/template

### DIFF
--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -161,7 +161,7 @@
         {% if show_moderation_status %}
           {% for field in group.list %}
           <div class="form-group">
-            <h3><label for="{{ field.id_for_label}}">{{ field.label }}</label></h3>
+            <h3><label for="{{ field.id_for_label }}">{{ field.label }}</label></h3>
             {{ field }}
            </div>
            {% endfor %}

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -161,7 +161,7 @@
         {% if show_moderation_status %}
           {% for field in group.list %}
           <div class="form-group">
-            <h3><label for="{{ field.auto_id}}">{{ field.label }}</label></h3>
+            <h3><label for="{{ field.id_for_label}}">{{ field.label }}</label></h3>
             {{ field }}
            </div>
            {% endfor %}
@@ -170,7 +170,7 @@
 
         {% for field in group.list %}
         <div class="form-group">
-          <h3><label for="{{ field.auto_id }}">{{ field.label }}</label></h3>
+          <h3><label for="{{ field.id_for_label }}">{{ field.label }}</label></h3>
           {{ field }}
         </div>
         {% endfor %}
@@ -194,7 +194,7 @@
 
             <div class="form-check col-lg-6">
               {% if field.label == "Other"%}
-                <label for="{{ field.auto_id }}">{{ field.label }}:</label>
+                <label for="{{ field.id_for_label }}">{{ field.label }}:</label>
                 {{field}}
               {% else %}
                 {{ field }}

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -90,7 +90,7 @@
             <strong>The following stories will be approved but may be
               labelled as ‘triggering’ when posted on the platform:</strong>
             <ul>
-              <li>Abuse (physical, sexual, emotional and verbal</li>
+              <li>Abuse (physical, sexual, emotional and verbal)</li>
               <li>Violence and Assault</li>
               <li>Drug and/or Alcohol use</li>
               <li>Mental Health Issues</li>
@@ -198,7 +198,7 @@
                 {{field}}
               {% else %}
                 {{ field }}
-                <label for="{{ field.auto_id }}">{{ field.label }}</label>
+                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
               {% endif %}
 
             </div>

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -180,7 +180,8 @@ def share_experience(request, uuid=False):
                         "moderation_status": moderation_status,
                     },
                 )            
-        # if a GET (or any other method) we'll create a blank form
+        # if a GET (or any other method) we'll either create a blank form or
+        # prepopulate form based on existing data. 
         else:
             if uuid:
                 # return data from oh.
@@ -189,12 +190,10 @@ def share_experience(request, uuid=False):
                 )
                 form = ShareExperienceForm(data)
                 title = "Edit experience"
-                viewable = data.get("viewable", False)
                 moderation_status = data.get("moderation_status", "not reviewed")
             else:
                 form = ShareExperienceForm()
                 title = "Share experience"
-                viewable = False
                 moderation_status = "not reviewed"
 
             return render(
@@ -204,7 +203,6 @@ def share_experience(request, uuid=False):
                     "form": form,
                     "uuid": uuid,
                     "title": title,
-                    "viewable": viewable,
                     "moderation_status": moderation_status,
                 },
             )


### PR DESCRIPTION
Thanks to @mastoffel's feedback on #512 I had a look over the `share_experience` view and template and fixed some more minor things: 

1. I removed the unused `viewable` variable that was passed on into the template but wasn't used anywhere
2. There was another minor bug in which the `<label for="field_id"/>` didn't work for the public sharing option, due to it being a custom declaration to make @mastoffel's excellent JS work more nicely. I've fixed that and also unified using the right label throughout the template to avoid future issues. 