### PR TITLE
fix urlencode in story title

### DIFF
--- a/server/apps/main/templates/main/deletion_confirmation.html
+++ b/server/apps/main/templates/main/deletion_confirmation.html
@@ -16,7 +16,7 @@
         Are you sure?
       </h1>
       <p class="confirmation-title-text">
-        You are about to delete the experience: {{title}}.
+        You are about to delete the experience: {{title|unquote_html}}.
       </p>
     </div>
 

--- a/server/apps/main/templates/main/deletion_success.html
+++ b/server/apps/main/templates/main/deletion_success.html
@@ -12,7 +12,7 @@
   <div class="confirmation-container">
     <div class="confirm_success">
       <h1 class="big-heading title-text-yellow">Success!</h1>
-      <p class="confirmation-title-text">Experience '{{title}}' deleted.</p>
+      <p class="confirmation-title-text">Experience '{{title|unquote_html}}' deleted.</p>
     </div>
  </div>
     <div class="to-do-container">

--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -9,6 +9,7 @@
 {% block content %}
 
 <!--Share Experiences Form-->
+<div class="container">
 <section id="share-form">
 
   <div class="row">
@@ -240,5 +241,5 @@
 
 
 </section>
-
+</div>
 {% endblock %}

--- a/server/apps/main/templates/main/story_table.html
+++ b/server/apps/main/templates/main/story_table.html
@@ -54,7 +54,7 @@
     <a href="{{ file.download_url }}" class="btn btn-secondary" target="_blank">Download</a>
 </td>
 <td>
-    <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.description %}" class="btn btn-danger">Delete</a>
+    <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.description|urlencode:"" %}" class="btn btn-danger">Delete</a>
 </td>
 </tr>
 {% comment %} {% empty %}

--- a/server/apps/main/templatetags/custom_tags.py
+++ b/server/apps/main/templatetags/custom_tags.py
@@ -1,6 +1,9 @@
 from django import template
 # from django.contrib.auth.models import Group
 from ..views import is_moderator
+from django.template.defaultfilters import register
+from urllib.parse import unquote 
+
 
 register = template.Library()
 
@@ -17,3 +20,7 @@ def toggle_story(val):
   
 register.simple_tag(is_moderator)  
   
+
+@register.filter
+def unquote_html(value):
+    return unquote(value)


### PR DESCRIPTION
This closes #527 that @helendduncan spotted: Title's of experiences can contain `/` and we are passing those titles for the deletion confirmation page in order to avoid another look-up on Open Humans. So far this fails because the `/` is being interpreted as part of a URL. 

I've changed the `My Stories` view to only pass the title after going through the `urlencode` filter. And then made a custom filter to re-create the actual title in the confirmation/success page. 