### PR TITLE
Support sending of moderation messages

### DIFF
--- a/config/.env.actions
+++ b/config/.env.actions
@@ -39,5 +39,5 @@ DJANGO_DATABASE_PORT=5432
 # Refer to https://django-open-humans.readthedocs.io/en/latest/modules/getting-started.html for more information
 OPENHUMANS_CLIENT_ID=A_CLIENT_ID
 OPENHUMANS_CLIENT_SECRET=A_CLIENT_SECRET
-OPENHUMANS_APP_BASE_URL=http://localhost:8000/openhumans/complete
+OPENHUMANS_APP_BASE_URL=http://localhost:8000
 OH_PROJ_PAGE="https://example.com"

--- a/config/.env.template
+++ b/config/.env.template
@@ -43,5 +43,5 @@ DJANGO_DATABASE_PORT=5432
 # Refer to https://django-open-humans.readthedocs.io/en/latest/modules/getting-started.html for more information
 OPENHUMANS_CLIENT_ID=A_CLIENT_ID
 OPENHUMANS_CLIENT_SECRET=A_CLIENT_SECRET
-OPENHUMANS_APP_BASE_URL=http://localhost:8000/openhumans/complete
+OPENHUMANS_APP_BASE_URL=http://localhost:8000
 OH_PROJ_PAGE="https://example.com"

--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -3,6 +3,8 @@ import json
 import io
 import uuid
 import requests
+import os
+import textwrap
 from django.contrib.auth.models import Group
 from django.forms.models import model_to_dict
 from django.conf import settings
@@ -544,8 +546,8 @@ def paginate_stories(request, paginator, page):
 def number_stories(stories, items_per_page):
     """
     Adds a number field to each story for continuous numbering across pages
-    
-    Stories can be either PublicExperience objects (for the shared stories page) 
+
+    Stories can be either PublicExperience objects (for the shared stories page)
     or dictionaries (for the my_stories page)
     """
     # Calculate the start index for the current page
@@ -589,3 +591,21 @@ def get_latest_change_reply(experience_id):
         pass
 
     return change_reply, changed_at
+
+def get_moderator_message():
+    leaf_name = "mod_message.txt"
+    module_dir = os.path.dirname(__file__)
+    file_path = os.path.join(module_dir, leaf_name)
+    subject = ""
+    message = ""
+    with open(file_path, "r") as f:
+        subject = f.readline()
+        for line in f:
+            message += line
+    return subject, message
+
+def message_wrap(text, width):
+    """
+    Wrap the text to the given width, but retain paragraph breaks (empty lines)
+    """
+    return "\n".join(map(lambda para: "\n".join(textwrap.wrap(para, width)), text.split("\n")))

--- a/server/apps/main/mod_message.txt
+++ b/server/apps/main/mod_message.txt
@@ -1,0 +1,21 @@
+Your story on AutSPACEs has been moderated
+Dear AutSPACEs community member,
+
+Thank you for submitting the following story to the AutSPACEs platform:
+
+"{title}"
+
+The moderation status of your story has changed. To see the latest information for your story, please visit the AutSPACEs site and navigate to the "My Stories" page.
+
+Alternatively, to go directly to the story, select this link:
+
+{story}
+
+Thank you again for contributing to the AutSPACES community.
+
+Best wishes from the AutSPACEs community.
+
+You can disable these alerts at any time from your profile page:
+
+{profile}
+

--- a/server/apps/main/tests/test_helpers.py
+++ b/server/apps/main/tests/test_helpers.py
@@ -5,7 +5,7 @@ from server.apps.main.helpers import reformat_date_string, get_review_status, \
     is_moderator, make_tags, extract_experience_details, delete_single_file_and_pe, delete_PE, \
     model_to_form, process_trigger_warnings, update_public_experience_db, \
     get_oh_metadata, get_oh_file, get_oh_combined, moderate_page, choose_moderation_redirect, \
-    extract_triggers_to_show
+    extract_triggers_to_show, get_moderator_message, message_wrap
 
 from openhumans.models import OpenHumansMember
 from server.apps.main.models import PublicExperience, ExperienceHistory
@@ -349,5 +349,33 @@ class StoryHelper(TestCase):
         allowed_triggers = {'abuse', 'violet', 'dasies', 'mentalhealth', 'nigella', 'orchids'}
         trigger_list = extract_triggers_to_show(allowed_triggers)
         assert('abuse' in trigger_list and 'mentalhealth' in trigger_list)
-        assert('violence' not in trigger_list and 'drugs' not in trigger_list 
+        assert('violence' not in trigger_list and 'drugs' not in trigger_list
                and 'negbody' not in trigger_list and 'other' not in trigger_list)
+
+    def test_moderator_message_exists(self):
+        """
+        Tests that the message sent to users when the moderation status changes
+        can be read in from file correctly.
+        """
+        # This will assert if it fails
+        subject, message = get_moderator_message()
+        # Let's make some assumptions about a minimal length subject and message
+        assert len(subject) > 4
+        assert len(message) > 4
+        # Let's assume a message that doesn't state where it's coming from isn't doing its job
+        self.assertIn('AutSPACEs', message)
+
+    def test_message_wrap(self):
+        """
+        Test that the message wrapping code wraps to the given line length but leaves
+        paragraph breaks (empty lines) alone.
+        """
+        text = "This is a very long long string. "
+        length = len(text)
+        text = text * 10
+        # Ensure paragraph breaks are retained
+        text = '\n\n'.join([text] * 3)
+        text = message_wrap(text, length)
+        assert text.count("\n") == 31
+        for line in text.split("\n"):
+            assert len(line) <= length


### PR DESCRIPTION
Adds the functionality to send messages to the user when the moderation of their stories change. This relies on the option being enabled in their profile.

The 'mod_message.txt' file contains the text of the message. It has some formatting requirements:

1. The first line is the subject line.
2. All subsequent lines will form the message body.
3. {story}, {profile}, {title} and {status} will be replaced with the URL of the story, the URL of the user's profile, the story title and the new moderation status of the story respectively.