### PR TITLE
Add warning dialogues to moderation page

### DIFF
--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -155,20 +155,20 @@
         <p><i>{{experience_difference}}</i></p>
       </div>
 
-      <template id="template-control" style="display: none;">
+      <template id="template-control" class="template-hidden">
         <div class="dropdown control">
           <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Reason for moderation
           </button>
           <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Includes identity or sensitive data" data-href="identity">Identity or sensitive data</a></li>
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Discriminatory or belittling content" data-href="discriminatory">Discriminatory or belittling</a></li>
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Includes a racial slur" data-href="racial-slurs">Racial slur</a></li>
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Making assumptions when writing on behalf of others" data-href="are-you-making-assumptions">Assumptions on behalf of others</a></li>
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Including your own subjective details when writing on behalf of others" data-href="are-you-adding-subjective-detail">Own subjectivity on behalf of others</a></li>
-            <li><a class="dropdown-item addreason moderation-red" data-reason="Responding to someone else's story" data-href="responding-to-others">Response to someone else's story</a></li>
-            <li><a class="dropdown-item addreason moderation-amber" data-reason="Includes swear words or disability slurs" data-href="swear-words">Swear words or disability slurs</a></li>
-            <li><a class="dropdown-item addreason moderation-amber" data-reason="Potentially triggering to some users" data-href="swear-words">Triggering to some users</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Includes identity or sensitive data" data-href="identity" data-severity="red">Identity or sensitive data</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Discriminatory or belittling content" data-href="discriminatory" data-severity="red">Discriminatory or belittling</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Includes a racial slur" data-href="racial-slurs" data-severity="red">Racial slur</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Making assumptions when writing on behalf of others" data-href="are-you-making-assumptions" data-severity="red">Assumptions on behalf of others</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Including your own subjective details when writing on behalf of others" data-href="are-you-adding-subjective-detail" data-severity="red">Own subjectivity on behalf of others</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Responding to someone else's story" data-href="responding-to-others" data-severity="red">Response to someone else's story</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Includes swear words or disability slurs" data-href="swear-words" data-severity="amber">Swear words or disability slurs</a></li>
+            <li><a class="dropdown-item addreason" data-reason="Potentially triggering to some users" data-href="swear-words" data-severity="amber">Triggering to some users</a></li>
           </ul>
         </div>
       </template>
@@ -287,7 +287,7 @@
 
         <h5>Moderation reasons to be passed back to the author</h5>
 
-        <p>Highlight a portion of the experience text to add a reason.</p>
+        <p>Highlight a portion of the experience text to add a reason. These comments will be sent to the author on review completion.</p>
         <div id="reason-titles">
           <div class="d-flex flex-row">
             <div class="p-2 col col-lg-7 text"><b>Relevant text</b></div>
@@ -306,7 +306,7 @@
         </template>
 
         <div class='form-group'>
-          <input type="submit" class="btn btn-outline-dark btn-lg float-right" value="Submit">
+          <input type="submit" class="btn btn-outline-dark btn-lg float-right" id="submitBtn" value="Submit">
         </div>
       </form>
     </div>
@@ -314,5 +314,41 @@
     <script src="{% static 'js/moderation-replies.js' %}"></script>
   </div>
 </section>
+
+  <template id="template-text-not-reviewed-comments" class="template-hidden">
+    <p>It's not possible to record <i>Moderation reasons</i> for stories that haven't been reviewed.</p>
+    <p>Please set the <i>Moderation status</i> to <i>in review</i> to hold reasons for later use, or set the status to <i>accepted</i> or <i>rejected</i> to send the reasons to the author now.</p>
+  </template>
+
+  <template id="template-text-reject-no-comments" class="template-hidden">
+    <p>You are rejecting the story without providing a reason. Are you sure you want to continue?</p>
+  </template>
+
+  <template id="template-text-approve-comments" class="template-hidden">
+    <p>When approving a story you can cite <span class="word-amber">Amber</span> reasons, but not <span class="word-red">Red</span> reasons. Stories containing <span class="word-red">Red</span> reasons must be rejected.</p>
+  </template>
+
+  <!-- Modal for the submit button -->
+  <div class="modal fade" id="submitModal" tabindex="-1" role="dialog" aria-labelledby="submitModalLabel" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="submitModalLabel">Moderation reasons</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body" id="modal-text">
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-primary" id="closeModal" data-dismiss="modal">Close</button>
+          <button type="button" class="btn btn-secondary" id="cancelModal" data-dismiss="modal">Cancel</button>
+          <button type="button" class="btn btn-primary" id="submitForm">Continue</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="{% static 'js/moderation-dialogue.js' %}"></script>
 </div>
 {% endblock %}

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -23,7 +23,7 @@ from django.contrib import messages
 
 from .helpers import (
     is_moderator,
-    model_to_form,
+    public_experience_model_to_form,
     extract_experience_details,
     reformat_date_string,
     get_review_status,
@@ -46,12 +46,13 @@ from .helpers import (
     get_latest_change_reply,
     structure_change_reply,
     number_stories,
-    get_moderator_message,
+    get_message,
     message_wrap,
 )
 
 from server.apps.users.helpers import (
     user_profile_exists,
+    get_user_profile,
 )
 
 logger = logging.getLogger(__name__)
@@ -195,6 +196,7 @@ def share_experience(request, uuid=False):
                                 messages.WARNING,
                                 "{}: {}".format(field.label, error),
                             )
+
                 if uuid:  # check if editing existing exp
                     moderation_status = PublicExperience.objects.get(
                         experience_id=uuid
@@ -520,90 +522,116 @@ def moderate_experience(request, uuid):
        80 charachters.
     """
     if request.user.is_authenticated and is_moderator(request.user):
-        model = PublicExperience.objects.get(experience_id=uuid)
+        public_experience = PublicExperience.objects.get(experience_id=uuid)
         if request.method == "POST":
             # get the data from the model
-            moderated_form = ModerateExperienceForm(request.POST)
-            moderated_form.is_valid()
+            form = ModerateExperienceForm(request.POST)
+            if form.is_valid():
+                # Get the (immutable) experience data
+                unchanged_experience_details = extract_experience_details(public_experience)
+                # Get the (mutable) trigger warnings
+                trigger_details = process_trigger_warnings(form)
 
-            # Get the (immutable) experience data
-            unchanged_experience_details = extract_experience_details(model)
-            # Get the (mutable) trigger warnings
-            trigger_details = process_trigger_warnings(moderated_form)
+                # validate
+                data = {**unchanged_experience_details, **trigger_details}
 
-            # validate
-            data = {**unchanged_experience_details, **trigger_details}
+                moderation_comments = data.pop("moderation_comments", None)
+                moderation_reply = data.pop("moderation_reply", "")
+                moderation_prior = data.pop("moderation_prior", "not moderated")
 
-            moderation_comments = data.pop("moderation_comments", None)
-            moderation_reply = data.pop("moderation_reply", "")
-            moderation_prior = data.pop("moderation_prior", "not moderated")
+                # get the users OH member id from the model
+                user_OH_member = public_experience.open_humans_member
 
-            # get the users OH member id from the model
-            user_OH_member = model.open_humans_member
+                # wrap in try/except in case user writing experience originally has left AutSPACEs
+                try:
+                    user_OH_member.delete_single_file(file_basename=f"{uuid}.json")
+                    upload(data, uuid, ohmember=user_OH_member)
+                    # update the PE object
+                    update_public_experience_db(
+                        data,
+                        uuid,
+                        ohmember=user_OH_member,
+                        editing_user=request.user.openhumansmember,
+                        change_type="Moderate",
+                        change_comments=moderation_comments,
+                        change_reply=moderation_reply,
+                    )
+                except Exception:
+                    # if user writing E has deauthorized autspaces, delete public experience
+                    delete_PE(uuid=uuid, ohmember=user_OH_member)
 
-            # wrap in try/except in case user writing experience originally has left AutSPACEs
-            try:
-                user_OH_member.delete_single_file(file_basename=f"{uuid}.json")
-                upload(data, uuid, ohmember=user_OH_member)
-                # update the PE object
-                update_public_experience_db(
-                    data,
-                    uuid,
-                    ohmember=user_OH_member,
-                    editing_user=request.user.openhumansmember,
-                    change_type="Moderate",
-                    change_comments=moderation_comments,
-                    change_reply=moderation_reply,
-                )
-            except Exception:
-                # if user writing E has deauthorized autspaces, delete public experience
-                delete_PE(uuid=uuid, ohmember=user_OH_member)
+                # send a message to the author if they've requested it
+                moderation_status = data.get("moderation_status", "")
+                moderation_string = moderation_status.title()
 
-            # send a message to the author if they've requested it
-            moderation_status = data.get("moderation_status", "")
-            moderation_string = moderation_status.title()
-            try:
-                profile = UserProfile.objects.get(user=request.user)
-                if (profile.comms_review and moderation_prior != moderation_status
+                profile = get_user_profile(user=request.user)
+                if (profile and profile.comms_review and moderation_prior != moderation_status
                     and moderation_status in ["approved", "rejected"]):
                     story_url = "{}/main/view/{}".format(settings.OPENHUMANS_APP_BASE_URL,
-                        model.experience_id)
+                        public_experience.experience_id)
                     profile_url = "{}/users/profile/".format(settings.OPENHUMANS_APP_BASE_URL)
-                    subject, message = get_moderator_message()
-                    substitutes = {
-                        "story": story_url,
-                        "profile": profile_url,
-                        "title": model.title_text,
-                        "status": moderation_string,
-                    }
-                    subject = subject.format(**substitutes)
-                    message = message.format(**substitutes)
-                    message = message_wrap(message, 80)
-                    request.user.openhumansmember.message(subject, message)
+                    subject, message = get_message("mod_message.txt")
+                    if subject and message:
+                        substitutes = {
+                            "story": story_url,
+                            "profile": profile_url,
+                            "title": public_experience.title_text,
+                            "status": moderation_string,
+                        }
+                        subject = subject.format(**substitutes)
+                        message = message.format(**substitutes)
+                        message = message_wrap(message, 80)
+                        request.user.openhumansmember.message(subject, message)
 
-            except Exception as e:
-                # This shouldn't happen, but if it does, it's reasonable to
-                # assume the user hasn't chosen to receive messages, or the
-                # message text file hasn't been created
-                print("Exception when attempting to send moderation message: {}".format(str(e)))
+                # redirect to a new URL:
+                status = choose_moderation_redirect(moderation_prior)
+                return redirect(
+                    "{}?status={}".format(reverse("main:moderation_list"), status)
+                )
+            else:
+                # Form didn't validate correctly
+                for error in form.non_field_errors():
+                    messages.add_message(
+                        request,
+                        messages.WARNING,
+                        "{}".format(error)
+                    )
 
-            # redirect to a new URL:
-            status = choose_moderation_redirect(moderation_prior)
-            return redirect(
-                "{}?status={}".format(reverse("main:moderation_list"), status)
-            )
+                experience_title = public_experience.title_text
+                experience_text = public_experience.experience_text
+                experience_difference = public_experience.difference_text
+                experience_history = public_experience.experiencehistory_set.all().order_by(
+                    "-changed_at"
+                )
+                for history_item in experience_history:
+                    history_item.change_reply = structure_change_reply(history_item.change_reply)
+
+                return render(
+                    request,
+                    "main/moderate_experience.html",
+                    {
+                        "form": form,
+                        "uuid": uuid,
+                        "experience_title": experience_title,
+                        "experience_text": experience_text,
+                        "experience_difference": experience_difference,
+                        "experience_history": experience_history,
+                        "show_moderation_status": True,
+                        "title": "Moderate experience",
+                    },
+                )
 
         else:
-            experience_title = model.title_text
-            experience_text = model.experience_text
-            experience_difference = model.difference_text
-            experience_history = model.experiencehistory_set.all().order_by(
-                "changed_at"
+            experience_title = public_experience.title_text
+            experience_text = public_experience.experience_text
+            experience_difference = public_experience.difference_text
+            experience_history = public_experience.experiencehistory_set.all().order_by(
+                "-changed_at"
             )
             for history_item in experience_history:
                 history_item.change_reply = structure_change_reply(history_item.change_reply)
 
-            form = model_to_form(model, disable_moderator=True)
+            form = public_experience_model_to_form(public_experience, disable_moderator=True)
             return render(
                 request,
                 "main/moderate_experience.html",

--- a/server/apps/users/helpers.py
+++ b/server/apps/users/helpers.py
@@ -38,3 +38,18 @@ def user_submitted_profile(user):
         submitted = False
     return submitted
 
+def get_user_profile(user):
+    """
+    Attempts to get the profile for a user.
+
+    Args:
+        user: request.user
+
+    Returns:
+        The UserProfile associated with the user if it exists, None otherwise
+    """
+    try:
+        uo = UserProfile.objects.get(user=user)
+    except UserProfile.DoesNotExist:
+        uo = None
+    return uo

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -620,6 +620,10 @@ body {
   color: #fcbd7e;
 }
 
+.template-hidden {
+  display: "hidden";
+}
+
 /* USER PROFILE PAGE */
 
 .profile-section {

--- a/static/js/moderation-dialogue.js
+++ b/static/js/moderation-dialogue.js
@@ -1,0 +1,67 @@
+$(() => {
+  let submitModal = new bootstrap.Modal($('#submitModal').get(0));
+
+  // Attach the dialogue check to the submit button
+  $('#submitBtn').on('click', (event) => {
+    let moderation_status = $('#id_moderation_status').val();
+    let shouldShowModal = false;
+    let text = ""
+    let reasons = [];
+    try {
+      let moderation_reply = $("#id_moderation_reply").val()
+      if (moderation_reply) {
+        reasons = JSON.parse(moderation_reply) || []
+      }
+    } catch(e) {
+      console.log('Error parsing submitted moderation reasons JSON: ' + e.message)
+    }
+    let reason_count = reasons.length;
+    let red_count = 0;
+    reasons.forEach((item) => {if (item.severity == 'red') {red_count +=1;}});
+
+    if ((reason_count > 0) && (moderation_status == 'not reviewed')) {
+      // The user is trying to set the story to 'not reviewed' but added moderation comments
+      text = $('#template-text-not-reviewed-comments');
+      $('#closeModal').show();
+      $('#cancelModal,#submitForm').hide();
+      shouldShowModal = true;
+    }
+    else if ((reason_count == 0) && (moderation_status == 'rejected')) {
+      // The user is trying reject a story without giving any reasons
+      text = $('#template-text-reject-no-comments');
+      $('#closeModal').hide();
+      $('#cancelModal,#submitForm').show();
+      shouldShowModal = true;
+    }
+    else if ((red_count > 0) && (moderation_status == 'approved')) {
+      // Check whether there are any "Red" reasons/
+      // The user is trying reject a story without giving any reasons
+      text = $('#template-text-approve-comments');
+      $('#closeModal').show();
+      $('#cancelModal,#submitForm').hide();
+      shouldShowModal = true;
+    }
+
+    if (shouldShowModal) {
+      // Show the dialogue box
+      $('#modal-text').empty().append(text.clone().prop('content'));
+
+      event.preventDefault();
+      submitModal.show();
+    }
+    else {
+      // Skip the dialogue box and just submit the form
+      $('.form-context').submit();
+    }
+  });
+
+  // When the submit button is clicked in the modal popup, submit the form
+  $('#submitForm').on('click', function () {
+    submitModal.hide();
+    $('.form-context').submit();
+  });
+});
+
+
+
+

--- a/static/js/moderation-replies.js
+++ b/static/js/moderation-replies.js
@@ -8,7 +8,24 @@ $(function() {
   var controlOpen = false
   var reasons = []
   // Initialise the reason section
+  try {
+    let moderation_reply = $("#id_moderation_reply").val()
+    if (moderation_reply) {
+      reasons = JSON.parse(moderation_reply) || []
+    }
+  } catch(e) {
+    console.log('Error parsing moderation reasons JSON: ' + e.message)
+    console.log('JSON string: "' + $("#id_moderation_reply").val() + '"');
+  }
+  applySeverityFormatting();
   generateReasons()
+
+  function applySeverityFormatting() {
+    // Style the menu items to match their severity
+    // This avoids us having to duplicate the severity info
+    control.find('[data-severity="red"]').addClass("moderation-red");
+    control.find('[data-severity="amber"]').addClass("moderation-amber");
+  }
 
   function forwardSelection(selection) {
     // Returns true if the selection was made forwards, otherwise false
@@ -56,7 +73,8 @@ $(function() {
     control.prop('text', text)
     controlOpen = true
     control.find(".addreason").on("click", function(event) {
-      addReason($(this).data("reason"), $(this).data("href"), text)
+      addReason($(this).data("reason"), $(this).data("href"),
+        $(this).data("severity"), text)
       hideReasons()
       event.stopPropagation()
     })
@@ -74,9 +92,9 @@ $(function() {
     document.getSelection().removeAllRanges()
   }
 
-  function addReason(reason, href, text) {
+  function addReason(reason, href, severity, text) {
     // Adds a moderation reason to the list
-    reasons.push({reason: reason, href: href, text: text})
+    reasons.push({reason: reason, href: href, severity: severity, text: text})
     generateReasons()
   }
 


### PR DESCRIPTION
Under certain circumstances it may not make sense to submit a review:

1. If the story is being rejected without a reason.
2. If the status is being set to 'not reviewed' but has review comments.

This change adds a dialogue box to warn the user in the case of 1, and block the user in the case of 2.

Fixes #525.