### PR TITLE
Use get_user_profile to get the UserProfile object

### DIFF
--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -334,13 +334,11 @@ def list_public_experiences(request):
         # Check the allowed triggers
         allowed_triggers = set(request.GET.keys())
 
-    if "searched" not in request.GET:
-        try:
-            profile = UserProfile.objects.get(user=request.user)
+    if request.user.is_authenticated and "searched" not in request.GET:
+        profile = get_user_profile(request.user)
+        if profile:
             user_data = model_to_dict(profile)
             allowed_triggers = set([key for key in user_data if user_data[key]])
-        except UserProfile.DoesNotExist:
-            pass
 
     # Get a list of allowed triggers
     triggers_to_show = extract_triggers_to_show(allowed_triggers)

--- a/server/apps/users/views.py
+++ b/server/apps/users/views.py
@@ -10,6 +10,7 @@ from .models import UserProfile
 from .forms import UserProfileForm
 from .helpers import (
     user_profile_exists,
+    get_user_profile,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,13 +31,13 @@ def user_profile(request, first_visit=False):
 
             return redirect("users:profile")
         else:
-            try:
-                profile = UserProfile.objects.get(user=request.user)
+            profile = get_user_profile(request.user)
+            if profile:
                 data = model_to_dict(profile)
                 # If the profile has been submitted this can't be the user's first visit
                 first_visit &= not profile.profile_submitted
                 form = UserProfileForm(data)
-            except UserProfile.DoesNotExist:
+            else:
                 form = UserProfileForm()
             oh_member = request.user.openhumansmember
             return render(


### PR DESCRIPTION
The get_user_profile helper function will return None of the user profile doesn't exist, rather than triggering an exception. These changes switch to using the helper function to avoid potentially errors iif the user isn't logged in.

Also adds a unit test to catch the error case.

Fixes #552.