### PR TITLE
move templates to partials

### DIFF
--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -155,23 +155,8 @@
         <p><i>{{experience_difference}}</i></p>
       </div>
 
-      <template id="template-control" class="template-hidden">
-        <div class="dropdown control">
-          <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            Reason for moderation
-          </button>
-          <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
-            <li><a class="dropdown-item addreason" data-reason="Includes identity or sensitive data" data-href="identity" data-severity="red">Identity or sensitive data</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Discriminatory or belittling content" data-href="discriminatory" data-severity="red">Discriminatory or belittling</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Includes a racial slur" data-href="racial-slurs" data-severity="red">Racial slur</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Making assumptions when writing on behalf of others" data-href="are-you-making-assumptions" data-severity="red">Assumptions on behalf of others</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Including your own subjective details when writing on behalf of others" data-href="are-you-adding-subjective-detail" data-severity="red">Own subjectivity on behalf of others</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Responding to someone else's story" data-href="responding-to-others" data-severity="red">Response to someone else's story</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Includes swear words or disability slurs" data-href="swear-words" data-severity="amber">Swear words or disability slurs</a></li>
-            <li><a class="dropdown-item addreason" data-reason="Potentially triggering to some users" data-href="swear-words" data-severity="amber">Triggering to some users</a></li>
-          </ul>
-        </div>
-      </template>
+      <!-- Load dropdown options for JS moderation code  --> 
+      {% include 'main/partials/template_moderation_dropdown.html' %}
 
       <hr/>
 
@@ -315,18 +300,8 @@
   </div>
 </section>
 
-  <template id="template-text-not-reviewed-comments" class="template-hidden">
-    <p>It's not possible to record <i>Moderation reasons</i> for stories that haven't been reviewed.</p>
-    <p>Please set the <i>Moderation status</i> to <i>in review</i> to hold reasons for later use, or set the status to <i>accepted</i> or <i>rejected</i> to send the reasons to the author now.</p>
-  </template>
-
-  <template id="template-text-reject-no-comments" class="template-hidden">
-    <p>You are rejecting the story without providing a reason. Are you sure you want to continue?</p>
-  </template>
-
-  <template id="template-text-approve-comments" class="template-hidden">
-    <p>When approving a story you can cite <span class="word-amber">Amber</span> reasons, but not <span class="word-red">Red</span> reasons. Stories containing <span class="word-red">Red</span> reasons must be rejected.</p>
-  </template>
+  <!-- Load texts for warning layover under different conditions  --> 
+  {% include 'main/partials/template_moderation_warnings.html' %}
 
   <!-- Modal for the submit button -->
   <div class="modal fade" id="submitModal" tabindex="-1" role="dialog" aria-labelledby="submitModalLabel" aria-hidden="true">

--- a/server/apps/main/templates/main/partials/template_moderation_dropdown.html
+++ b/server/apps/main/templates/main/partials/template_moderation_dropdown.html
@@ -1,0 +1,21 @@
+{% load static %}
+
+<!-- List of dropdown moderation replies with severity (amber/red) + link to CoC item  --> 
+
+<template id="template-control" class="template-hidden">
+    <div class="dropdown control">
+      <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        Reason for moderation
+      </button>
+      <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+        <li><a class="dropdown-item addreason" data-reason="Includes identity or sensitive data" data-href="identity" data-severity="red">Identity or sensitive data</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Discriminatory or belittling content" data-href="discriminatory" data-severity="red">Discriminatory or belittling</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Includes a racial slur" data-href="racial-slurs" data-severity="red">Racial slur</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Making assumptions when writing on behalf of others" data-href="are-you-making-assumptions" data-severity="red">Assumptions on behalf of others</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Including your own subjective details when writing on behalf of others" data-href="are-you-adding-subjective-detail" data-severity="red">Own subjectivity on behalf of others</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Responding to someone else's story" data-href="responding-to-others" data-severity="red">Response to someone else's story</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Includes swear words or disability slurs" data-href="swear-words" data-severity="amber">Swear words or disability slurs</a></li>
+        <li><a class="dropdown-item addreason" data-reason="Potentially triggering to some users" data-href="swear-words" data-severity="amber">Triggering to some users</a></li>
+      </ul>
+    </div>
+  </template>

--- a/server/apps/main/templates/main/partials/template_moderation_warnings.html
+++ b/server/apps/main/templates/main/partials/template_moderation_warnings.html
@@ -1,0 +1,16 @@
+{% load static %}
+
+<!-- moderation warning statuses to be displayed on conditions  --> 
+
+<template id="template-text-not-reviewed-comments" class="template-hidden">
+    <p>It's not possible to record <i>Moderation reasons</i> for stories that haven't been reviewed.</p>
+    <p>Please set the <i>Moderation status</i> to <i>in review</i> to hold reasons for later use, or set the status to <i>accepted</i> or <i>rejected</i> to send the reasons to the author now.</p>
+  </template>
+
+  <template id="template-text-reject-no-comments" class="template-hidden">
+    <p>You are rejecting the story without providing a reason. Are you sure you want to continue?</p>
+  </template>
+
+  <template id="template-text-approve-comments" class="template-hidden">
+    <p>When approving a story you can cite <span class="word-amber">Amber</span> reasons, but not <span class="word-red">Red</span> reasons. Stories containing <span class="word-red">Red</span> reasons must be rejected.</p>
+  </template>

--- a/server/apps/main/templates/main/partials/template_moderation_warnings.html
+++ b/server/apps/main/templates/main/partials/template_moderation_warnings.html
@@ -5,12 +5,12 @@
 <template id="template-text-not-reviewed-comments" class="template-hidden">
     <p>It's not possible to record <i>Moderation reasons</i> for stories that haven't been reviewed.</p>
     <p>Please set the <i>Moderation status</i> to <i>in review</i> to hold reasons for later use, or set the status to <i>accepted</i> or <i>rejected</i> to send the reasons to the author now.</p>
-  </template>
+</template>
 
-  <template id="template-text-reject-no-comments" class="template-hidden">
+ <template id="template-text-reject-no-comments" class="template-hidden">
     <p>You are rejecting the story without providing a reason. Are you sure you want to continue?</p>
-  </template>
+</template>
 
-  <template id="template-text-approve-comments" class="template-hidden">
+<template id="template-text-approve-comments" class="template-hidden">
     <p>When approving a story you can cite <span class="word-amber">Amber</span> reasons, but not <span class="word-red">Red</span> reasons. Stories containing <span class="word-red">Red</span> reasons must be rejected.</p>
-  </template>
+</template>


### PR DESCRIPTION
Closes #553. 

This cleans up the `moderate_experience.html` template a bit by moving the template information used by the JS into its own separate partials. 