### PR TITLE
fix nplusone whitelist

### DIFF
--- a/server/settings/environments/development.py
+++ b/server/settings/environments/development.py
@@ -117,6 +117,7 @@ NPLUSONE_LOGGER = logging.getLogger('django')
 NPLUSONE_LOG_LEVEL = logging.WARN
 NPLUSONE_WHITELIST = [
     {'model': 'admin.*'},
+    {'label': 'n_plus_one', 'model': 'users.UserProfile'}
 ]
 
 


### PR DESCRIPTION
![Screenshot 2023-08-08 at 11 18 37](https://github.com/alan-turing-institute/AutSPACEs/assets/674899/fc9e61f0-0261-43e6-86e4-440372c8f41b)

Currently, the admin backend in development gives the above error when trying to look at the UserProfile admin pages. This is because it loops over all `UserProfile`s which in turn lazy-loads the `user.username` from the database, c.f. users.models:

```
def __str__(self):
        return "Profile for {}".format(self.user.username)
```

These added requests are mainly due to how the admin backend works in presenting & loading this data and I don't think we use the `str` method anywhere else (otherwise we'd already have stumbled over those errors). 

Given this, I just added it to the whitelist, for the nplusone library to not check for this any more (as it's only for performance monitoring)