### PR TITLE
Use sessions for storing experience title

### DIFF
--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -628,3 +628,19 @@ def message_wrap(text, width):
     Wrap the text to the given width, but retain paragraph breaks (empty lines)
     """
     return "\n".join(map(lambda para: "\n".join(textwrap.wrap(para, width)), text.split("\n")))
+
+def experience_titles_for_session(files):
+    """
+    take a member.list_files() list of files and add them to dict
+    of the form 
+    {"titles":{
+        "uuid": "title",
+        "uuid2": "title2"
+    }}
+    To be added to session
+    """
+    titles = {}
+    for f in files:
+        if "uuid" in f['metadata'].keys():
+            titles[f['metadata']['uuid']] = f['metadata']['description']
+    return titles

--- a/server/apps/main/templates/main/deletion_confirmation.html
+++ b/server/apps/main/templates/main/deletion_confirmation.html
@@ -23,7 +23,7 @@
 
     <div class="row mx-0 py-4 justify-content-start">
       <div class="col-2">
-            <form action="{% url 'main:delete_exp' uuid title %}" method="post">{% csrf_token %}
+            <form action="{% url 'main:delete_exp' uuid %}" method="post">{% csrf_token %}
               <button type="submit" class="btn btn-danger btn-lg">Yes, Delete</button>
             </form>
       </div>

--- a/server/apps/main/templates/main/story_table.html
+++ b/server/apps/main/templates/main/story_table.html
@@ -54,7 +54,7 @@
     <a href="{{ file.download_url }}" class="btn btn-secondary" target="_blank">Download</a>
 </td>
 <td>
-    <a href="{% url 'main:delete_exp' file.metadata.uuid file.metadata.description|urlencode:"" %}" class="btn btn-danger">Delete</a>
+    <a href="{% url 'main:delete_exp' file.metadata.uuid %}" class="btn btn-danger">Delete</a>
 </td>
 </tr>
 {% comment %} {% empty %}

--- a/server/apps/main/tests/test_views.py
+++ b/server/apps/main/tests/test_views.py
@@ -527,7 +527,7 @@ class Views(TestCase):
         c = Client()
         c.force_login(self.user_a)
         response = c.post(
-            "/main/delete/3653328c-f956-11ed-9803-0242ac140003/Placeholder%20text/"
+            "/main/delete/3653328c-f956-11ed-9803-0242ac140003/"
         )
         assert response.status_code == 200
 

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
         name="moderate_public_experiences",
     ),
     re_path(r"moderation_list/?$", views.moderation_list, name="moderation_list"),
-    path("delete/<uuid>/<title>/", views.delete_experience, name="delete_exp"),
+    path("delete/<uuid>/", views.delete_experience, name="delete_exp"),
     path("share_exp/", views.share_experience, name="share_exp"),
     path("edit/<uuid>/", views.share_experience, name="edit_exp"),
     path("moderate/<uuid>/", views.moderate_experience, name="moderate_exp"),

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -289,8 +289,7 @@ def delete_experience(request, uuid):
     """
     Delete experience from PE databacse and OH
     """
-    # TODO: we currently are passing title via url because it is nice to display it in the confirmation. We could improve the deletion process by having a javascript layover.
-
+    
     titles = request.session.get('titles', {})
     title = titles.get(uuid, "no title")
 

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -48,6 +48,7 @@ from .helpers import (
     number_stories,
     get_message,
     message_wrap,
+    experience_titles_for_session,
 )
 
 from server.apps.users.helpers import (
@@ -284,11 +285,14 @@ def view_experience(request, uuid):
 
 
 # @vcr.use_cassette("server/apps/main/tests/fixtures/delete_exp.yaml", filter_query_parameters=['access_token'])
-def delete_experience(request, uuid, title):
+def delete_experience(request, uuid):
     """
     Delete experience from PE databacse and OH
     """
     # TODO: we currently are passing title via url because it is nice to display it in the confirmation. We could improve the deletion process by having a javascript layover.
+
+    titles = request.session.get('titles', {})
+    title = titles.get(uuid, "no title")
 
     if request.user.is_authenticated:
         if request.method == "POST":
@@ -451,6 +455,9 @@ def my_stories(request):
         files = request.user.openhumansmember.list_files()
         context = {"files": files}
         context = reformat_date_string(context)
+
+        # add experience titles to session for deletion pages
+        request.session['titles']= experience_titles_for_session(files)
 
         # Define the number of items per page
         items_per_page = settings.EXPERIENCES_PER_PAGE


### PR DESCRIPTION
This PR addresses a `TODO` item that was left in the code: 

Trying to delete an experience takes a user from the list view to a new confirmation page. On that page we want to display the title of the experience without having to query Open Humans again. So far this is achieved by passing the experience title as a URL parameter: 

`path("delete/<uuid>/<title>/", views.delete_experience, name="delete_exp"),`

This is a bit clunky and could potentially break depending on the characters people use in their titles etc (though we did some proper character escaping). 

A better solution is to store these titles somewhere locally in somewhat ephemeral storage. Django provides a `session` backend for such purposes and we already use that middleware implicitly without actually making use of it. In our current setup the Postgres database has a session store. I've updated the `my_stories` and `delete_experience` views to make use of this: 

- When loading the `my_stories` view a helper now sets a session dictionary that links all experience `uuid`s to the experience titles. 
- The `delete_confirmation` view we can than grab this data from the session without having to pass anything else around, both on `GET` and `POST`


@helendduncan I'm flagging you as I think this relates – by a potential similar approach – to the question of how to handle people going back from an individual experience page to the main listing and how/where to store all the trigger warning opt-ins/outs (c.f. #531 and #540) 