### PR TITLE
Add SelectRequired ChoiceField widget with disabled entry

### DIFF
--- a/server/apps/users/forms.py
+++ b/server/apps/users/forms.py
@@ -1,5 +1,11 @@
 from django import forms
 
+class SelectRequired(forms.Select):
+    # Disables items in the drop down list that have an empty value
+    # See https://docs.djangoproject.com/en/4.2/ref/forms/renderers/#built-in-template-form-renderers
+    # See also the ChoiceWidget.create_option() implementation in django/forms/widgets.py
+    option_template_name = "users/select_option_disable_empty.html"
+
 class UserProfileForm(forms.Form):
 
     autistic_identifications = [
@@ -8,7 +14,7 @@ class UserProfileForm(forms.Form):
         ("no", "No"),
         ("unspecified", "Prefer not to say"),
     ]
-    autistic_identification = forms.ChoiceField(choices = autistic_identifications, widget = forms.Select(),
+    autistic_identification = forms.ChoiceField(choices = autistic_identifications, widget = SelectRequired(),
                                            label="Do you identify as autistic?",
                                            help_text="AutSPACEs is focusing on collecting and sharing the voices and lived experiences of autistic people, which is why this is a mandatory question. If you select <i>prefer not to say</i> your answers will be considered as coming from a non-autistic person, labeled as such and e.g. not used for research.",
                                            required=True)

--- a/server/apps/users/templates/users/select_option_disable_empty.html
+++ b/server/apps/users/templates/users/select_option_disable_empty.html
@@ -1,0 +1,1 @@
+<option value="{{ widget.value|stringformat:'s' }}"{% include "django/forms/widgets/attrs.html" %}{% if widget.value|stringformat:'s' == '' %} disabled="disabled"{% endif %}>{{ widget.label }}</option>


### PR DESCRIPTION
Adds a ChoiceField widget that allows the default (empty) option to be disabled, so that the user is encouraged to select one of the other options. The option is added to the "Do you identify as Autistic" field.

Contributes to #569