### PR TITLE
Remind the user to complete their profile

### DIFF
--- a/server/apps/users/helpers.py
+++ b/server/apps/users/helpers.py
@@ -24,8 +24,8 @@ def user_submitted_profile(user):
     Determines whether the user has ever hit the Submit button on the profile page.
 
     This is the best indication we have of whether the user has ever filled out
-    the profile page (because they might legitimately want the profile to be
-    emtpy).
+    the profile page, because they'll be blocked from submitting it if they've
+    filled out the required fields and all others are optional.
 
     Args:
         user: request.user

--- a/server/apps/users/templates/users/partials/profile_messages.html
+++ b/server/apps/users/templates/users/partials/profile_messages.html
@@ -1,0 +1,29 @@
+{% load static %}
+
+<!-- profile messages displayed conditionally -->
+
+{% if first_visit == True %}
+<div class="container alert-container">
+  <div class="alert alert-info" role="alert">
+    Welcome to AutSPACEs!
+  </div>
+  <div class="alert alert-info" role="alert">
+    We&#x27;re super excited to have you here. As this is your first visit,
+    please take the time to complete your profile as this helps us and others make
+    the most of the experiences you share. Return here to update your details at any time.
+  </div>
+</div>
+{% endif %}
+{% if request_profile == True %}
+<div class="container alert-container">
+  <div class="alert alert-info" role="alert">
+    <p>Thank you for sharing your experience!</p>
+    <p>Depending on your choice, your experience will be useful for the general
+       public, research or both!</p>
+    <p>To make your experience even more useful, it would be great if you could
+       take the time to fill out your details. You can come back here to update
+       your details at any time.</p>
+</div>
+</div>
+{% endif %}
+

--- a/server/apps/users/templates/users/profile.html
+++ b/server/apps/users/templates/users/profile.html
@@ -10,27 +10,8 @@
 
 <script src="{% static 'js/activate-profile.js' %}"></script>
 
-{% if first_visit == True %}
-<div class="container alert-container">
-  <div class="alert alert-info" role="alert">
-    Welcome to AutSPACEs!
-  </div>
-  <div class="alert alert-info" role="alert">
-    We&#x27;re super excited to have you here. As this is your first visit,
-    please take the time to complete your profile as this helps us and others make 
-    the most of the experiences you share. Return here to update your details at any time.
-  </div>
-</div>
-{% endif %}
-{% if request_profile == True %}
-<div class="container alert-container">
-  <div class="alert alert-info" role="alert">
-    We&#x27;d love it if you could fill out some of your details, to allow us and
-    others to make the most of your shared experiences. 
-    You can come back here to update your details at any time.
-  </div>
-</div>
-{% endif %}
+<!-- Load profile messages  -->
+{% include 'users/partials/profile_messages.html' %}
 
 <!-- User Profile Form -->
 <section id="user-profile-form">

--- a/server/apps/users/urls.py
+++ b/server/apps/users/urls.py
@@ -6,5 +6,6 @@ app_name = "servers.apps.users"
 urlpatterns = [
     path("profile/", views.user_profile, name="profile"),
     path("greetings/", views.user_profile, {"first_visit": True}, name="greetings"),
+    path("reminder/", views.user_profile, {"remind_user": True}, name="reminder"),
     path("delete/", views.user_profile_delete, name="delete"),
 ]

--- a/server/apps/users/views.py
+++ b/server/apps/users/views.py
@@ -20,7 +20,7 @@ from .helpers import (
 
 logger = logging.getLogger(__name__)
 
-def user_profile(request, first_visit=False):
+def user_profile(request, first_visit=False, remind_user=False):
     """
     User profile page.
     """
@@ -50,7 +50,7 @@ def user_profile(request, first_visit=False):
                     "form": form,
                     "oh_id": oh_member.oh_id,
                     "first_visit": first_visit,
-                    "request_profile": False,
+                    "request_profile": remind_user,
                 })
     else:
         return redirect("index")


### PR DESCRIPTION
If the user submits an experience with either the research or public flags set, but hasn't yet completed their user profile, this change will redirect the user to the profile page with a suitable message requesting that they complete it.

Fixes #534.