### PR TITLE
Add configs for user test deployment to fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG PYTHON_VERSION=3.9.16-slim-buster
+
+FROM python:${PYTHON_VERSION}
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+
+# install psycopg2 dependencies.
+RUN apt-get update && apt-get install -y \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /code
+
+WORKDIR /code
+
+RUN pip install poetry
+COPY pyproject.toml poetry.lock /code/
+RUN poetry config virtualenvs.create false
+RUN poetry install --no-root --no-interaction
+COPY . /code
+
+EXPOSE 8000
+
+CMD ["gunicorn", "--bind", ":8000", "--workers", "1", "server.wsgi"]

--- a/dev_readme.md
+++ b/dev_readme.md
@@ -137,6 +137,22 @@ Select the user account you would like to be a moderator. On the resulting page 
 
 From now on the user should be able to see the Moderator pages in the front-end of AutSPACEs.
 
+### Test deployment for user testing
+
+The repo provides a simple `Dockerfile` and `fly.toml` for quick and free deployments for testing to _fly.io_ (which provides very small compute resources for free). This setup is not designed for an actual production deployment, but to allow people to interact with the prototype for e.g. user testing purposes. 
+
+On a Mac with `brew` installed the following set of commands should be enough to deploy: 
+
+To prepare the repo: 
+
+```
+brew install flyctl
+fly launch
+fly deploy
+```
+
+Before running the deploy step, one will have to add all the information that otherwise resides in the `.env` (see above) on the fly.io web interface.
+
 
 ## Extra Tips
 
@@ -148,3 +164,4 @@ From now on the user should be able to see the Moderator pages in the front-end 
 ## Docker overview 
 
 You might find the chapter on [reproducible computational environments](https://the-turing-way.netlify.app/reproducible-research/renv.html) and spectifically the section on [containers](https://the-turing-way.netlify.app/reproducible-research/renv/renv-containers.html) in _The Turing Way_ useful!
+

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,28 @@
+# fly.toml app configuration file generated for weathered-darkness-2449 on 2023-08-31T09:19:36+01:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "weathered-darkness-2449"
+primary_region = "cdg"
+console_command = "/code/manage.py shell"
+
+[build]
+
+#[deploy]
+#  release_command = "python manage.py migrate"
+
+[env]
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = true
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[statics]]
+  guest_path = "/code/static"
+  url_prefix = "/static/"

--- a/poetry.lock
+++ b/poetry.lock
@@ -570,6 +570,22 @@ numpy = ["numpy (>=1.13.0)", "numpy (>=1.15.0)", "numpy (>=1.18.0)", "numpy (>=1
 tests = ["check-manifest (>=0.42)", "mock (>=1.3.0)", "pytest (==5.4.3)", "pytest (>=6)", "pytest-cov (>=2.10.1)", "pytest-isort (>=1.2.0)", "pytest-pycodestyle (>=2)", "pytest-pycodestyle (>=2.2.0)", "pytest-pydocstyle (>=2)", "pytest-pydocstyle (>=2.2.0)", "sphinx (>=3)", "tox (>=3.7.0)"]
 
 [[package]]
+name = "dj-database-url"
+version = "2.1.0"
+description = "Use Database URLs in your Django Application."
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "dj-database-url-2.1.0.tar.gz", hash = "sha256:f2042cefe1086e539c9da39fad5ad7f61173bf79665e69bf7e4de55fa88b135f"},
+    {file = "dj_database_url-2.1.0-py3-none-any.whl", hash = "sha256:04bc34b248d4c21aaa13e4ab419ae6575ef5f10f3df735ce7da97722caa356e0"},
+]
+
+[package.dependencies]
+Django = ">=3.2"
+typing-extensions = ">=3.10.0.0"
+
+[[package]]
 name = "django"
 version = "4.2.3"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
@@ -2548,7 +2564,8 @@ files = [
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win32.whl", hash = "sha256:763d65baa3b952479c4e972669f679fe490eee058d5aa85da483ebae2009d231"},
     {file = "ruamel.yaml.clib-0.2.7-cp310-cp310-win_amd64.whl", hash = "sha256:d000f258cf42fec2b1bbf2863c61d7b8918d31ffee905da62dede869254d3b8a"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:045e0626baf1c52e5527bd5db361bc83180faaba2ff586e763d3d5982a876a9e"},
-    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_12_6_arm64.whl", hash = "sha256:721bc4ba4525f53f6a611ec0967bdcee61b31df5a56801281027a3a6d1c2daf5"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:1a6391a7cabb7641c32517539ca42cf84b87b667bad38b78d4d42dd23e957c81"},
+    {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:9c7617df90c1365638916b98cdd9be833d31d337dbcd722485597b43c4a215bf"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:41d0f1fa4c6830176eef5b276af04c89320ea616655d01327d5ce65e50575c94"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win32.whl", hash = "sha256:f6d3d39611ac2e4f62c3128a9eed45f19a6608670c5a2f4f07f24e8de3441d38"},
     {file = "ruamel.yaml.clib-0.2.7-cp311-cp311-win_amd64.whl", hash = "sha256:da538167284de58a52109a9b89b8f6a53ff8437dd6dc26d33b57bf6699153122"},
@@ -3007,7 +3024,7 @@ files = [
 name = "typing-extensions"
 version = "3.10.0.2"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 files = [
@@ -3320,4 +3337,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "3.9.16"
-content-hash = "a3367b4dbca744a836b0c5a9570e7b27f094c92f8245c90526aa5e25b4bddbb9"
+content-hash = "0f279c03d65f5f340a792f2282b89518c3276b11183365af2567efdf8676fe35"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ structlog = "^20.1"
 django-open-humans = "^0.1.6"
 vcrpy = "^4.2.1"
 coverage = "^7.2.2"
+dj-database-url = "^2.1.0"
 
 
 [tool.poetry.dev-dependencies]

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -109,6 +109,16 @@ DATABASES = {
     },
 }
 
+# database for flyio
+
+import dj_database_url
+import os 
+
+if os.environ.get('DATABASE_URL'):
+    DATABASES['default'] = dj_database_url.config(
+        conn_max_age=600,
+        conn_health_checks=True,
+    )
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -94,20 +94,22 @@ WSGI_APPLICATION = 'server.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': config('POSTGRES_DB'),
-        'USER': config('POSTGRES_USER'),
-        'PASSWORD': config('POSTGRES_PASSWORD'),
-        'HOST': config('DJANGO_DATABASE_HOST'),
-        'PORT': config('DJANGO_DATABASE_PORT', cast=int),
-        'CONN_MAX_AGE': config('CONN_MAX_AGE', cast=int, default=60),
-        'OPTIONS': {
-            'connect_timeout': 10,
+if not os.environ.get('DATABASE_URL'):
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql_psycopg2',
+            'NAME': config('POSTGRES_DB'),
+            'USER': config('POSTGRES_USER'),
+            'PASSWORD': config('POSTGRES_PASSWORD'),
+            'HOST': config('DJANGO_DATABASE_HOST'),
+            'PORT': config('DJANGO_DATABASE_PORT', cast=int),
+            'CONN_MAX_AGE': config('CONN_MAX_AGE', cast=int, default=60),
+            'OPTIONS': {
+                'connect_timeout': 10,
+            },
         },
-    },
-}
+    }
 
 # database for flyio
 
@@ -115,10 +117,12 @@ import dj_database_url
 import os 
 
 if os.environ.get('DATABASE_URL'):
-    DATABASES['default'] = dj_database_url.config(
-        conn_max_age=600,
-        conn_health_checks=True,
-    )
+    DATABASES = {
+        'default': dj_database_url.config(
+            conn_max_age=600,
+            conn_health_checks=True,
+        ),
+    }
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/server/settings/components/common.py
+++ b/server/settings/components/common.py
@@ -94,6 +94,9 @@ WSGI_APPLICATION = 'server.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
+import os 
+
+
 if not os.environ.get('DATABASE_URL'):
 
     DATABASES = {
@@ -113,10 +116,8 @@ if not os.environ.get('DATABASE_URL'):
 
 # database for flyio
 
-import dj_database_url
-import os 
-
 if os.environ.get('DATABASE_URL'):
+    import dj_database_url
     DATABASES = {
         'default': dj_database_url.config(
             conn_max_age=600,


### PR DESCRIPTION
This PR tweaks our config slightly and adds the files necessary to deploy a test environment to fly.io to allow participants in the user testing to explore the website without having to share remote control via zoom. 

It adds/changes: 

1. The `Dockerfile` used for the fly.io deployment 
2. The `fly.toml` for the config on their end
3. The `dj-database-url` package which loads the postgres database from the `DATABASE_URL` environment variable that fly uses
4. edits the `common.py` config to detect if a `DATABASE_URL` is set in order to identify that we're on fly.io to then use that config rather than the local dev setup.