### PR TITLE
Expand seed management cmd 4 user testing

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -9,8 +9,8 @@ console_command = "/code/manage.py shell"
 
 [build]
 
-#[deploy]
-#  release_command = "python manage.py migrate"
+[deploy]
+  release_command = "python manage.py migrate"
 
 [env]
   PORT = "8000"

--- a/server/apps/main/management/commands/seed_db.py
+++ b/server/apps/main/management/commands/seed_db.py
@@ -17,6 +17,17 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         file_name = options["file"]
         
+        # delete existing OH members & PublicExperiences, 
+        # should reset DB except admin users before doing import
+
+        oh_members = OpenHumansMember.objects.all()
+        for ohm in oh_members:
+            ohm.delete()
+
+        pes = PublicExperience.objects.all()
+        for pe in pes:
+            pe.delete()
+
         # create OH member for public experience import
         data = {"access_token": 'foo',
                 "refresh_token": 'bar',

--- a/server/apps/main/tests/test_management_commands.py
+++ b/server/apps/main/tests/test_management_commands.py
@@ -1,0 +1,52 @@
+from io import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+from openhumans.models import OpenHumansMember
+from server.apps.main.models import PublicExperience
+
+class SeedDBTest(TestCase):
+    def test_seed_empty_db(self):
+        """
+        Test that correctly populate from empty db (first load)
+        """
+        oh_members_before = OpenHumansMember.objects.all()
+        pe_before = PublicExperience.objects.all()
+        assert len(oh_members_before) == 0
+        assert len(pe_before) == 0
+        call_command("seed_db", file="server/apps/main/tests/fixtures/example_experiences_seed.csv")
+        oh_members_after = OpenHumansMember.objects.all()
+        assert len(oh_members_after) == 1
+        pe_after = PublicExperience.objects.all()
+        assert len(pe_after) == 7
+
+    def test_seed_filled_db(self):
+        """
+        Test that correctly populate from empty db (first load)
+        """
+        # generate prior OH member & PE
+        data = {"access_token": 'foo',
+        "refresh_token": 'bar',
+        "expires_in": 36000}
+        existing_ohm = OpenHumansMember.create(oh_id="12345678",data=data)
+        existing_ohm.save()
+        pe_data = {
+                "title_text": 'foo',
+                "experience_text": 'bar',
+                "difference_text": 'foobar',
+                "moderation_status": "approved",
+                "first_hand_authorship": "True",
+                }
+        PublicExperience.objects.create(open_humans_member=existing_ohm, experience_id=1001, **pe_data)
+
+        # check that there's 1 existing OHM & PE
+        oh_members_before = OpenHumansMember.objects.all()
+        pe_before = PublicExperience.objects.all()
+        assert len(oh_members_before) == 1
+        assert len(pe_before) == 1
+        # run command
+        call_command("seed_db", file="server/apps/main/tests/fixtures/example_experiences_seed.csv")
+        # check there's still only single OHM + 7 PEs
+        oh_members_after = OpenHumansMember.objects.all()
+        assert len(oh_members_after) == 1
+        pe_after = PublicExperience.objects.all()
+        assert len(pe_after) == 7

--- a/server/settings/environments/development.py
+++ b/server/settings/environments/development.py
@@ -26,6 +26,10 @@ ALLOWED_HOSTS = [
     '[::1]',
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    "https://" + config('DOMAIN_NAME'),
+    "http://" + config('DOMAIN_NAME'),
+    ]
 
 # Installed apps for development only:
 

--- a/server/settings/environments/production.py
+++ b/server/settings/environments/production.py
@@ -20,6 +20,10 @@ ALLOWED_HOSTS = [
     'localhost',
 ]
 
+CSRF_TRUSTED_ORIGINS = [
+    "https://" + config('DOMAIN_NAME'),
+    "http://" + config('DOMAIN_NAME'),
+    ]
 
 # Staticfiles
 # https://docs.djangoproject.com/en/2.2/ref/contrib/staticfiles/


### PR DESCRIPTION
This PR expands the seeding a bit for the upcoming user testing: 

1. Instead of trying to expand on any existing data, the management command now first deletes all `OpenHumansMember` and `PublicExperience` objects in the database. This is relevant for restoring the DB back to the "default" for user testing
2. The `seed_db` command is now covered by tests
3. I noticed that I had forgotten to uncomment the release stage in the fly.io deployment, which was necessary to make it migrate the DB following @helendduncan's authorship improvements!