### PR TITLE
Avoid help page menu overlapping text

### DIFF
--- a/server/apps/main/templates/main/about_us.html
+++ b/server/apps/main/templates/main/about_us.html
@@ -12,8 +12,11 @@
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-3">
-        <div class="list-group col-lg-3 cotent-list" id="content-bar">
+      <div class="col-lg-3">
+        <div class="col-lg-3" id="content-bar-filler">
+        <!-- Space filler to avoid the main text shifting leftwards -->
+        </div>
+        <div class="list-group col-lg-3 content-list" id="content-bar">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
              href="#about-autspaces">About AutSPACEs<span class="badge badge-pill"></span></a>
@@ -34,7 +37,7 @@
         </a>
         </div>
       </div>
-      <div class="about-content col-9" data-offset="0" style="padding: 2% 8%">
+      <div class="about-content col-lg-9" data-offset="0" style="padding: 2% 8%">
         <div class="about-content-section">
           <h5 class="text-info" id="about-autspaces"><em></em>About AutSPACEs</h5>
           <p>The “Aut” in AutSPACEs refers to Autistic people, and the “SPACEs” is an acronym which refers to exploring

--- a/server/apps/main/templates/main/about_us.html
+++ b/server/apps/main/templates/main/about_us.html
@@ -4,16 +4,16 @@
 
 {% block body_attributes%} data-spy="scroll" data-target="#content-bar" {% endblock %}
 
+{% block content %}
 
-
-  {% block content %}
+<script src="{% static 'js/menu-alignment.js' %}"></script>
 
 <!--Contents-->
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-3">
-        <div class="col-lg-3" id="content-bar-filler">
+      <div id="menu-container" class="col-lg-3">
+        <div id="content-bar-filler" class="col-lg-3">
         <!-- Space filler to avoid the main text shifting leftwards -->
         </div>
         <div class="list-group col-lg-3 content-list" id="content-bar">
@@ -37,7 +37,7 @@
         </a>
         </div>
       </div>
-      <div class="about-content col-lg-9" data-offset="0" style="padding: 2% 8%">
+      <div id="text-container" class="about-content col-lg-9" data-offset="0" style="padding: 2% 8%">
         <div class="about-content-section">
           <h5 class="text-info" id="about-autspaces"><em></em>About AutSPACEs</h5>
           <p>The “Aut” in AutSPACEs refers to Autistic people, and the “SPACEs” is an acronym which refers to exploring

--- a/server/apps/main/templates/main/code_of_conduct.html
+++ b/server/apps/main/templates/main/code_of_conduct.html
@@ -10,8 +10,11 @@
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-3">
-        <div class="list-group col-lg-3 cotent-list" id="content-bar">
+      <div class="col-lg-3">
+        <div class="col-lg-3" id="content-bar-filler">
+        <!-- Space filler to avoid the main text shifting leftwards -->
+        </div>
+        <div class="list-group col-lg-3 content-list" id="content-bar">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#code-of-conduct">Code of Conduct<span class="badge badge-pill"></span></a>
@@ -20,15 +23,15 @@
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#acceptable-content">What Is and Isn't Acceptable to Mention in Stories<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#writing-for-others">Additional Guidelines for Writing on Behalf of Others<<span class="badge badge-pill"></span></a>
+              href="#writing-for-others">Additional Guidelines for Writing on Behalf of Others<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#responding-to-others">Responding to Others' Stories<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#reporting-breaches">How to Report Breaches of Code of Conduct and Safeguarding<<span class="badge badge-pill"></span></a>
+              href="#reporting-breaches">How to Report Breaches of Code of Conduct and Safeguarding<span class="badge badge-pill"></span></a>
         </div>
       </div>
 
-      <div class="topic-content col-9" data-offset="0" data-target="#content-bar"
+      <div class="topic-content col-lg-9" data-offset="0" data-target="#content-bar"
            style="padding: 2% 8%">
         <div class="code-of-conduct">
           <h5 class="text-info" id="code-of-conduct"><em></em>Code of Conduct</h5>

--- a/server/apps/main/templates/main/code_of_conduct.html
+++ b/server/apps/main/templates/main/code_of_conduct.html
@@ -6,15 +6,17 @@
 
 {% block content %}
 
+<script src="{% static 'js/menu-alignment.js' %}"></script>
+
 <!--Contents-->
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-3">
-        <div class="col-lg-3" id="content-bar-filler">
+      <div id="menu-container" class="col-lg-3">
+        <div id="content-bar-filler" class="col-lg-3">
         <!-- Space filler to avoid the main text shifting leftwards -->
         </div>
-        <div class="list-group col-lg-3 content-list" id="content-bar">
+        <div id="content-bar" class="list-group col-lg-3 content-list">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#code-of-conduct">Code of Conduct<span class="badge badge-pill"></span></a>
@@ -31,7 +33,7 @@
         </div>
       </div>
 
-      <div class="topic-content col-lg-9" data-offset="0" data-target="#content-bar"
+      <div id="text-container" class="topic-content col-lg-9" data-offset="0" data-target="#content-bar"
            style="padding: 2% 8%">
         <div class="code-of-conduct">
           <h5 class="text-info" id="code-of-conduct"><em></em>Code of Conduct</h5>

--- a/server/apps/main/templates/main/help.html
+++ b/server/apps/main/templates/main/help.html
@@ -10,8 +10,11 @@
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-3">
-        <div class="list-group col-lg-3 cotent-list" id="content-bar">
+      <div class="col-lg-3">
+        <div class="col-lg-3" id="content-bar-filler">
+        <!-- Space filler to avoid the main text shifting leftwards -->
+        </div>
+        <div class="list-group col-lg-3 content-list" id="content-bar">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
             href="#sharing-stories">Sharing Stories on AutSPACEs<span class="badge badge-pill"></span></a>
@@ -20,7 +23,7 @@
           </div>
       </div>
 
-      <div class="topic-content col-9" data-offset="0" data-target="#content-bar" style="padding: 2% 8%">
+      <div class="topic-content col-lg-9" data-offset="0" data-target="#content-bar" style="padding: 2% 8%">
         <div class="faq-class">
           <h5 class="text-info" id="sharing-stories">What Stories Should I Share On AutSPACEs?</h5>
           <p>

--- a/server/apps/main/templates/main/help.html
+++ b/server/apps/main/templates/main/help.html
@@ -6,24 +6,26 @@
 
 {% block content %}
 
+<script src="{% static 'js/menu-alignment.js' %}"></script>
+
 <!--Contents-->
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-3">
-        <div class="col-lg-3" id="content-bar-filler">
+      <div id="menu-container" class="col-lg-3">
+        <div id="content-bar-filler" class="col-lg-3">
         <!-- Space filler to avoid the main text shifting leftwards -->
         </div>
-        <div class="list-group col-lg-3 content-list" id="content-bar">
+        <div id="content-bar" class="list-group col-lg-3 content-list">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
             href="#sharing-stories">Sharing Stories on AutSPACEs<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-            href="#moderating-autspaces">Moderating AutSPACEs<span class="badge badge-pill"></span></a> 
+            href="#moderating-autspaces">Moderating AutSPACEs<span class="badge badge-pill"></span></a>
           </div>
       </div>
 
-      <div class="topic-content col-lg-9" data-offset="0" data-target="#content-bar" style="padding: 2% 8%">
+      <div id="text-container" class="topic-content col-lg-9" data-offset="0" data-target="#content-bar" style="padding: 2% 8%">
         <div class="faq-class">
           <h5 class="text-info" id="sharing-stories">What Stories Should I Share On AutSPACEs?</h5>
           <p>

--- a/server/apps/main/templates/main/what_autism_is.html
+++ b/server/apps/main/templates/main/what_autism_is.html
@@ -4,17 +4,19 @@
 
 {% block body_attributes%} data-spy="scroll" data-target="#content-bar" {% endblock %}
 
-  {% block content %}
+{% block content %}
+
+<script src="{% static 'js/menu-alignment.js' %}"></script>
 
 <!--Contents-->
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-lg-3">
-        <div class="col-lg-3" id="content-bar-filler">
+      <div id="menu-container" class="col-lg-3">
+        <div id="content-bar-filler" class="col-lg-3">
         <!-- Space filler to avoid the main text shifting leftwards -->
         </div>
-        <div class="list-group col-lg-3 content-list" id="content-bar">
+        <div id="content-bar" class="list-group col-lg-3 content-list">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#about-autspaces">About Autism<span class="badge badge-pill"></span></a>
@@ -23,9 +25,8 @@
         </div>
       </div>
 
-
-    <div class="about-content col-lg-9" data-offset="0" data-target="#content-bar"
-         style="padding: 2% 8%">
+    <div id="text-container" class="about-content col-lg-9" data-offset="0"
+         data-target="#content-bar" style="padding: 2% 8%">
       <div class="about-autism">
         <h5 class="text-info" id="about-autspaces"><em></em>About Autism</h5>
         <p>Autism affects the way people communicate and experience the world around them.</p>

--- a/server/apps/main/templates/main/what_autism_is.html
+++ b/server/apps/main/templates/main/what_autism_is.html
@@ -10,8 +10,11 @@
 <section id="content">
   <div class="container-fluid">
     <div class="row">
-      <div class="col-3">
-        <div class="list-group col-lg-3 cotent-list" id="content-bar">
+      <div class="col-lg-3">
+        <div class="col-lg-3" id="content-bar-filler">
+        <!-- Space filler to avoid the main text shifting leftwards -->
+        </div>
+        <div class="list-group col-lg-3 content-list" id="content-bar">
           <h5 class="list-group-item content-title">Contents</h5>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#about-autspaces">About Autism<span class="badge badge-pill"></span></a>
@@ -21,7 +24,7 @@
       </div>
 
 
-    <div class="about-content col-9" data-offset="0" data-target="#content-bar"
+    <div class="about-content col-lg-9" data-offset="0" data-target="#content-bar"
          style="padding: 2% 8%">
       <div class="about-autism">
         <h5 class="text-info" id="about-autspaces"><em></em>About Autism</h5>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -17,6 +17,21 @@ body {
  position: fixed;
 }
 
+#content-bar-filler {
+ position: relative;
+}
+
+/*Responsive Design*/
+@media (max-width: 991px) {
+  #content-bar {
+   position: relative;
+  }
+
+  #content-bar-filler {
+   position: fixed;
+  }
+}
+
 .content-tile {
     font-size: 2.5em;
     font-weight: bold;
@@ -42,6 +57,7 @@ body {
   background: #F2F2F2;
   padding: 2% 5%;
   color:#000;
+  position: relative;
 }
 
 .footer-image {

--- a/static/js/menu-alignment.js
+++ b/static/js/menu-alignment.js
@@ -1,0 +1,42 @@
+$(function () {
+  above = false;
+  menu = $("#content-bar")
+  // Determine at which viewport height the menu should move to the top
+  threshold = menu.position().top + menu.height() + 100
+
+  // Moves the menu to the top or left
+  // set_above: true to move the menu to the top
+  //            false to move it to the left
+  function force_above(set_above) {
+    if (set_above) {
+      $("#menu-container").addClass("col-lg-12").removeClass("col-lg-3")
+      $("#text-container").addClass("col-lg-12").removeClass("col-lg-9")
+      menu.addClass("col-lg-12").removeClass("col-lg-3")
+      menu.css("position", "relative")
+    } else {
+      $("#menu-container").removeClass("col-lg-12").addClass("col-lg-3")
+      $("#text-container").removeClass("col-lg-12").addClass("col-lg-9")
+      menu.removeClass("col-lg-12").addClass("col-lg-3")
+      menu.css("position", "")
+    }
+    above = set_above;
+  }
+
+  // Function for checking whether the menu needs to be moved
+  function test_threshold() {
+    height = window.innerHeight;
+    if (height >= threshold && above) {
+      force_above(false);
+    } else if (height < threshold && !above) {
+      force_above(true);
+    }
+  }
+
+  // Call the check whenever the window is resized
+  $(window).on("resize", function() {
+    test_threshold();
+  });
+
+  // Call the check on document ready
+  test_threshold();
+});


### PR DESCRIPTION
When the width of the viewport is reduced below 992 pixels the menu along the left hand edge overlaps the text on the page. Using Bootstraps columns it should jump above the text, but this is prevented because the positioning of the menu is set to fixed (so that it stays on screen when the page is scrolled).

This change fixes this by creating a media selector that makes the menu position relative when the width of the page reduces below 992 pixels. An invisible column is also added to avoid the need to place the menu inside another column, and to prevent the text from shifting to the left when the menu position is set to fixed.

The footer position is also set to relative so that it goes over (rather than under) the menu to avoids a nasty overlap when viewport height is small.

Contributes to #576.