### PR TITLE
Adding Participant Information + clarify CoC vs content moderation

### DIFF
--- a/server/apps/main/templates/main/about_us.html
+++ b/server/apps/main/templates/main/about_us.html
@@ -138,7 +138,7 @@
         <div class="use-terms">
           <h5 class="heading-blue" id="use-terms"><em></em>Terms of Use</h5>
           <p> The AutSPACEs software itself is released under an open MIT license. This means that the code is freely available to reuse and modify for any purpose, as long as they credit the AutSPACEs community. Importantly, this does not extend to the data provided by AutSPACEs participants.</p>   
-          <p> The data we collect for researchers will only available by application, and researchers must commit to following our values to receive approval. We are currently working on a protocol to implement this.</p>
+          <p> The data we collect for researchers will only be available by application, and researchers must commit to following our values to receive approval. We are currently working on a protocol to implement this.</p>
         </div>
           <h5 class="heading-blue" id="our-values"><em></em>Our Values</h5>
           <p><b>"Nothing About Us Without Us"</b></p>

--- a/server/apps/main/templates/main/about_us.html
+++ b/server/apps/main/templates/main/about_us.html
@@ -107,7 +107,7 @@
         </div>
         <div class="about-content-section">
           <h5 class="heading-blue" id="data-usage"><em></em>Data Usage</h5>
-          <p>We will <b>never</b> sell your data or share it with anyone without your consent.</p>
+          <p>We will <b>never</b> sell your data.</p>
 
           <p>We believe that your data should belong to you, so it’s your choice what to do with it.</p>
 

--- a/server/apps/main/templates/main/about_us.html
+++ b/server/apps/main/templates/main/about_us.html
@@ -22,9 +22,9 @@
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
              href="#about-autspaces">About AutSPACEs<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-             href="#platform-usage">Platform Usage<span class="badge badge-pill"></span></a>
+             href="#platform-usage">How to use the Platform<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
-             href="#explore-autspaces">Explore AutSPACEs<span class="badge badge-pill"></span></a>
+             href="#explore-autspaces">Exploring AutSPACEs<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
              href="#data-usage">Data Usage<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center"
@@ -41,7 +41,7 @@
       <div id="text-container" class="about-content col-lg-9" style="padding: 2% 8%">
         <div class="about-content-section">
           <h5 class="heading-blue" id="about-autspaces"><em></em>About AutSPACEs</h5>
-          <p>The “Aut” in AutSPACEs refers to Autistic people, and the “SPACEs” is an acronym which refers to exploring
+          <p>The <i>“Aut”</i> in AutSPACEs refers to Autistic people, and the <i>“SPACEs”</i> is an acronym which refers to exploring
             Sensory Processing for Accessible Community Environments. This captures the aim of AutSPACEs which is to make
             spaces better for autistic people by learning about sensory processing and its impact.</p>
 
@@ -68,7 +68,12 @@
           </ul>
         </div>
         <div class="about-content-section">
-          <h5 class="heading-blue" id="platform-usage"><em></em>Platform Usage</h5>
+          <h5 class="heading-blue" id="platform-usage"><em></em>How to use the platform</h5>
+          <p>
+            This section gives a brief step-by-step overview of how AutSPACEs works. 
+            You can find more information in the <a href="{% url 'main:participant_information' %}">participant information</a> and 
+            <a href="{% url 'main:help' %}">help</a> sections.
+          </p>
           <h6 class="platform-list-title">1. Register with Open Humans</h6>
           <p>When you register you create a private and anonymous account with Open Humans. We work with Open Humans to
             make sure you have control over your data and that it is safe.</p>
@@ -77,8 +82,6 @@
             things that use that data.
 
             You can find out more about <a href="https://www.openhumans.org/about/" target="_blank" rel="noopener noreferrer">Open Humans</a> on their website.</p>
-
-          <p>We will never sell your data, and we will never share it without your consent.</p>
           <h6 class="platform-list-title">2. Share your story</h6>
           <p>Enter a description of how your senses affect you. For example: “I do not go on trains because they are too
             loud”.</p>
@@ -86,14 +89,14 @@
           <p>You can choose to share your story publicly, so people using AutSPACEs can learn from it, or privately, for
             research. You can also share both publicly and with researchers if you prefer.</p>
           <h6 class="platform-list-title">4. Story is checked</h6>
-          <p>If you want to make your story public, it will first be checked to make sure it follows our code of conduct.
+          <p>If you want to make your story public, it will first be checked to make sure it follows our <a href="{% url 'main:content_moderation_guidelines' %}">content moderation guidelines</a>.
             This is to keep AutSPACEs an autism-first, inclusive and welcoming space for all.</p>
           <h6 class="platform-list-title">5. Change your stories any time</h6>
           <p>You can view your own stories and edit them, or change who they are shared with any time, even once they are
             submitted.</p>
         </div>
         <div class="about-content-section">
-          <h5 class="heading-blue" id="explore-autspaces"><em></em>Explore AutSPACEs</h5>
+          <h5 class="heading-blue" id="explore-autspaces"><em></em>Exploring AutSPACEs</h5>
           <p>You do not need an account to explore AutSPACEs and read other people’s stories.</p>
 
           <p>If you are autistic, you may find other people who have similar sense experiences to you. You can discover tips
@@ -109,7 +112,7 @@
           <p>We believe that your data should belong to you, so it’s your choice what to do with it.</p>
 
           <p>If you choose to share your story with researchers, your story will be part of a dataset with other people’s
-            experiences, and researchers can apply to look at the dataset for the purposes of making the world better for
+            experiences, and researchers outside the AutSPACEs team will have to apply to look at the dataset for the purposes of making the world better for
             autistic people and their families. We will make sure that autistic people are involved in making decisions
             about
             who can look at the data. We have partnered with Open Humans to make sure your data is kept safe and secure. You
@@ -117,25 +120,25 @@
 
           <p>If you choose to make your experience public, your experience will first be checked over by a moderator to make
             sure
-            it follows our [code of conduct](link to code of conduct). We will let you know when a moderator has made a
-            decision about your experience. If they decide it does follow our code of conduct, it will be published
+            it follows our <a href="{% url 'main:content_moderation_guidelines' %}">content moderation guidelines</a>. We will let you know when a moderator has made a
+            decision about your experience. If they decide it does follow our guidelines, it will be published
             anonymously
             on this website. Anyone will be able to view your story, but your name will be kept private. You can make this
             choice by checking the box ‘share online with everyone’.</p>
 
-          <p>If you choose not to share your experience you can still view it by going to My Stories.</p>
+          <p>If you choose not to share your experience you can still view it by going to <a href="{% url 'main:my_stories' %}">My Stories.</a></p>
 
           <p>You can also choose to share with your story with researchers and make make your story public. You can do this
             by
             selecting ‘share with researchers’ and ‘share online with everyone’.</p>
 
-          <p>You can also change your mind at any time by going to My-Experiences and selecting which options you would
+          <p>You can also change your mind at any time by going to <a href="{% url 'main:my_stories' %}">My Stories.</a> and selecting which options you would
             prefer.</p>
         </div>
         <div class="use-terms">
           <h5 class="heading-blue" id="use-terms"><em></em>Terms of Use</h5>
           <p> The AutSPACEs software itself is released under an open MIT license. This means that the code is freely available to reuse and modify for any purpose, as long as they credit the AutSPACEs community. Importantly, this does not extend to the data provided by AutSPACEs participants.</p>   
-          <p> The data we collect for researchers is only available by application, and researchers must commit to following our values to receive approval. We are currently working on a protocol to implement this.</p>
+          <p> The data we collect for researchers will only available by application, and researchers must commit to following our values to receive approval. We are currently working on a protocol to implement this.</p>
         </div>
           <h5 class="heading-blue" id="our-values"><em></em>Our Values</h5>
           <p><b>"Nothing About Us Without Us"</b></p>

--- a/server/apps/main/templates/main/confirmation_page.html
+++ b/server/apps/main/templates/main/confirmation_page.html
@@ -27,8 +27,8 @@
       <div class="what-now-text">
           <ul>
           <li><p class="text">
-           If you chose to share your experience with the world, an autistic moderator
-            will check that it follows our code of conduct, and if it does, you will receive a confirmation and your
+           If you chose to share your experience with the world, a moderator
+            will check that it follows our content moderation guidelines, and if it does, you will receive a confirmation and your
               experience
             will then be published on this website.
           </p></li>

--- a/server/apps/main/templates/main/content_moderation_guidelines.html
+++ b/server/apps/main/templates/main/content_moderation_guidelines.html
@@ -50,8 +50,9 @@
           They were co-written by autistic people, the parents and carers of autistic people, and researchers with expertise in
           creating inclusive online spaces.</p>
 
-          <p>The lead investigator of AutSPACEs &mdash; Dr. Bastian Greshake Tzovaras &mdash; is ultimately responsible for enforcing
-          the Content Moderation Guidelines and is overseeing the moderation process. He can be contacted by emailing <a
+          <p>The lead investigators of AutSPACEs &mdash; Dr. Kirstie Whitaker and Dr. Bastian Greshake Tzovaras &mdash; are ultimately responsible for enforcing
+          the Content Moderation Guidelines and is overseeing the moderation process. They can be contacted by emailing 
+          <a href="mailto:kwhitaker@turing.ac.uk">kwhitaker@turing.ac.uk</a> and <a
           href="mailto:bgreshaketzovaras@turing.ac.uk">bgreshaketzovaras@turing.ac.uk</a>. Reports may be reviewed by other
           members of the research team, unless there is a conflict of interest, and will be kept confidential.</p>
 

--- a/server/apps/main/templates/main/content_moderation_guidelines.html
+++ b/server/apps/main/templates/main/content_moderation_guidelines.html
@@ -1,6 +1,6 @@
 {% extends 'main/application.html' %}
 {% load static %}
-{% block title %}AutSPACEs - Code of Conduct {% endblock %}
+{% block title %}AutSPACEs - Content Moderation Guidelines {% endblock %}
 
 {% block body_attributes%}  {% endblock %}
 
@@ -19,7 +19,7 @@
         <div id="content-bar" class="list-group col-lg-3 content-list">
           <div class="list-group-item content-title fw-bold">Contents</div>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#code-of-conduct">Code of Conduct<span class="badge badge-pill"></span></a>
+              href="#code-of-conduct">Content Moderation Guidelines<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#purpose">What the Platform Is (and Isn't) For<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
@@ -28,15 +28,13 @@
               href="#writing-for-others">Additional Guidelines for Writing on Behalf of Others<span class="badge badge-pill"></span></a>
           <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#responding-to-others">Responding to Others' Stories<span class="badge badge-pill"></span></a>
-          <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#reporting-breaches">How to Report Breaches of Code of Conduct and Safeguarding<span class="badge badge-pill"></span></a>
         </div>
       </div>
 
       <div id="text-container" class="topic-content col-lg-9" 
            style="padding: 2% 8%">
         <div class="code-of-conduct">
-          <h5 class="heading-blue" id="code-of-conduct"><em></em>Code of Conduct</h5>
+          <h5 class="heading-blue" id="code-of-conduct"><em></em>Content Moderation Guidelines</h5>
 
           <p>The AutSPACEs platform is an online space which puts autistic people first. We are committed to providing a
           safe and welcoming place for autistic people and their supporters to share experiences, knowing their voices will
@@ -44,16 +42,16 @@
 
           <p>AutSPACEs allows users to share stories publicly with other users as well as privately with researchers. In
           order for the platform to be a respectful and welcoming place for autistic people and other members of the
-          community, everyone sharing a story publicly will be required to follow this code of conduct. Before they are
+          community, everyone sharing a story publicly will be required to follow these content moderation guidelines. Before they are
           published all stories will be reviewed by a moderator who will use this document as guidance when making decisions
           as to whether a post can be approved or not.</p>
 
-          <p>This code of conduct exists for clarity and fairness, as well as to ensure the values of AutSPACEs are upheld.
+          <p>These content moderation guidelines exist for clarity and fairness, as well as to ensure the values of AutSPACEs are upheld.
           It was co-written by autistic people, the parents and carers of autistic people, and researchers with expertise in
           creating inclusive online spaces.</p>
 
-          <p>The lead investigator of AutSPACEs &mdash; Dr. Bastian Greshake Tzovaras &mdash; is responsible for enforcing
-          the Code of Conduct and overseeing the moderation process. She can be contacted by emailing <a
+          <p>The lead investigator of AutSPACEs &mdash; Dr. Bastian Greshake Tzovaras &mdash; is ultimately responsible for enforcing
+          the Content Moderation Guidelines and is overseeing the moderation process. He can be contacted by emailing <a
           href="mailto:bgreshaketzovaras@turing.ac.uk">bgreshaketzovaras@turing.ac.uk</a>. Reports may be reviewed by other
           members of the research team, unless there is a conflict of interest, and will be kept confidential.</p>
 
@@ -70,7 +68,7 @@
           year-old would not be permitted to post.</p>
 
           <p>As this is a data collection platform, users will have the option to share their stories with both researchers
-          and/or the public. Further information about how stories will be used by researchers is available [insert link].
+          and/or the public. Further information about how stories will be used by researchers will be available in the future [insert link].
           Only stories posted to the public will be moderated, all information below.</p>
 
           <p>As much as we would like to be able to help everyone with everything, that is unfortunately out of the scope of
@@ -242,13 +240,6 @@
           stories posted as a direct response to another post will be disapproved.</p>
 
           <p>However, as AutSPACEs is an anonymous platform, it is permissible to discuss stories on other sites.</p>
-        </div>
-
-        <div class="code-of-conduct">
-          <h5 class="heading-blue" id="reporting-breaches"><em></em>How to Report Breaches of Code of Conduct and
-          Safeguarding</h5>
-
-          <p>TBC</p>
         </div>
 
       </div>

--- a/server/apps/main/templates/main/content_moderation_guidelines.html
+++ b/server/apps/main/templates/main/content_moderation_guidelines.html
@@ -47,7 +47,7 @@
           as to whether a post can be approved or not.</p>
 
           <p>These content moderation guidelines exist for clarity and fairness, as well as to ensure the values of AutSPACEs are upheld.
-          It was co-written by autistic people, the parents and carers of autistic people, and researchers with expertise in
+          They were co-written by autistic people, the parents and carers of autistic people, and researchers with expertise in
           creating inclusive online spaces.</p>
 
           <p>The lead investigator of AutSPACEs &mdash; Dr. Bastian Greshake Tzovaras &mdash; is ultimately responsible for enforcing
@@ -68,7 +68,7 @@
           year-old would not be permitted to post.</p>
 
           <p>As this is a data collection platform, users will have the option to share their stories with both researchers
-          and/or the public. Further information about how stories will be used by researchers will be available in the future [insert link].
+          and/or the public. Further information about how stories will be used by researchers will be available in the future and announced in our newsletter.
           Only stories posted to the public will be moderated, all information below.</p>
 
           <p>As much as we would like to be able to help everyone with everything, that is unfortunately out of the scope of

--- a/server/apps/main/templates/main/help.html
+++ b/server/apps/main/templates/main/help.html
@@ -47,7 +47,7 @@
             <div class="row ">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>
@@ -67,7 +67,7 @@
             <div class="row ">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>
@@ -109,7 +109,7 @@
             <div class="row">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>
@@ -127,7 +127,7 @@
             <div class="row">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>
@@ -144,7 +144,7 @@
             <div class="row">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>
@@ -185,7 +185,7 @@
             <div class="row">
               <div class="col">
                 <a class="btn btn-outline-dark float-end"
-                  href="{% url 'main:code_of_conduct' %}" rel="noopener noreferrer">
+                  href="{% url 'main:content_moderation_guidelines' %}" rel="noopener noreferrer">
                   Read the code of conduct
                 </a>
               </div>

--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -32,7 +32,7 @@
               <p>AutSPACEs allows users to share stories publicly with other users as well as privately with researchers.
                 In order
                 for the platform to be a respectful and welcoming place for autistic people and other members of the
-                community, everyone sharing a story publicly will be required to follow this code of conduct. Before they
+                community, everyone sharing a story publicly will be required to follow our content moderation guidelines. Before they
                 are
                 published all stories will be reviewed by a moderator who will use this document as guidance when making
                 decisions as to whether a post can be approved or not.</p>

--- a/server/apps/main/templates/main/partials/footer.html
+++ b/server/apps/main/templates/main/partials/footer.html
@@ -20,9 +20,9 @@
 
     <div class="col-lg-3 footer-text">
       <h5>Policies</h5>
-      <p><a href="https://github.com/alan-turing-institute/AutisticaCitizenScience/tree/master/project-management/ethics-applications">Ethics</a></p>
-      <p>Terms of Use</p>
-      <p><a href="{% url 'main:code_of_conduct' %}">Code of Conduct</a></p>
+      <p><a href="{% url 'main:participant_information' %}">Ethics Information</a></p>
+      <p><a href="{% url 'main:content_moderation_guidelines' %}">Content Moderation Guidelines</a></p>
+      <p><a href="https://github.com/alan-turing-institute/AutSPACEs/blob/main/code-of-conduct.md">Community Code of Conduct</a></p>
     </div>
 
     <div class="col-lg-3 footer-text">

--- a/server/apps/main/templates/main/partials/navigation.html
+++ b/server/apps/main/templates/main/partials/navigation.html
@@ -37,7 +37,7 @@
             <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
               <li><a class="dropdown-item" href="{% url 'main:what_autism_is' %}">What is Autism</a></li>
               <li><a class="dropdown-item" href="{% url 'main:about_us' %}">About Us</a></li>
-              <li><a class="dropdown-item" href="{% url 'main:code_of_conduct' %}">Code of Conduct</a></li>
+              <li><a class="dropdown-item" href="{% url 'main:content_moderation_guidelines' %}">Content Moderation Guidelines</a></li>
               <li><a class="dropdown-item" href="{% url 'main:help' %}">Help</a></li>
             </ul>
           </li>

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -25,7 +25,7 @@
             <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#take-part">Do I have to take part?<span class="badge badge-pill"></span></a>
             <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
-              href="#what-will-happen">What will happen if I take part in AutSPACEs?<span class="badge badge-pill"></span></a>
+              href="#what-will-happen">What will happen if I choose to take part in AutSPACEs?<span class="badge badge-pill"></span></a>
             <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
               href="#confidentiality">Will my taking part in this project be kept confidential?<span class="badge badge-pill"></span></a>
             <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
@@ -99,7 +99,7 @@
             <p>
                 If you join AutSPACEs you will be able to contribute your own stories around sensory processing experiences in text form, 
                 alongside recommendations of what would have made that experience better. 
-                Additionally, we ask you to fill in a small profile with demographic information (age, gender, whether you identify as autistic). 
+                Additionally, we ask you to fill in a small profile with demographic information (age, gender, and whether you identify as autistic). 
             </p>
             <p>
                 Entering any of these data is optional and participation more broadly is voluntary. 
@@ -129,7 +129,7 @@
             </p>
             <p>
                 All your data and information will be handled according to 
-                The Alan Turing Institute Information Policy that you can read here 
+                The Alan Turing Institute Information Policy that you can read here:
                 <a href="https://www.turing.ac.uk/data-protection-policy">https://www.turing.ac.uk/data-protection-policy </a>
             </p>
     

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -191,7 +191,7 @@
         <div class="code-of-conduct">
             <h5 class="heading-blue" id="ethics-review">Ethical review of the study</h5>
             <p>
-                The project has been reviewed by The Alan Turing Institute’s Ethics Committee. 
+                The project has been reviewed by The Alan Turing Institute’s ethics panel, with reference number: [ADD REFERENCE NUMBER WHEN APPROVED]. 
                 You can <a href="https://github.com/alan-turing-institute/AutisticaCitizenScience/tree/master/project-management/ethics-applications">find our ethics documentation on GitHub</a>.
             </p>
         </div>

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -57,8 +57,14 @@
             </p>
             <p>
                 Every person is different. We want to gather many autistic people’s stories together. 
-                Our goal is to 1) share them with people who have similar experiences, 2) educate neurotypical people on how they can better support 
-                autistic people, and 3) advise people on how they can design and adapt spaces to improve autistic people’s lives. 
+                
+                Our goal is to 
+                <ol>
+                <li>share them with people who have similar experiences,</li>
+                <li>educate neurotypical people on how they can better support</li>
+                autistic people, and 
+                <li>advise people on how they can design and adapt spaces to improve autistic people’s lives.</li>
+                </ol>
             </p>
             <p>
                 <b>The purpose of this study is to investigate sensory differences experienced by autistic people by collecting sensory 
@@ -145,7 +151,8 @@
             </p>
             <p>
                 If you decide to make a story publicly accessible, a moderator from our research team will review it in accordance to our 
-                content moderation guidelines, to amongst other things avoid that it contains personal identifiable information.
+                <a href="{% url 'main:content_moderation_guidelines' %}">content moderation guidelines</a>, 
+                to amongst other things avoid that it contains personal identifiable information.
             </p>
             <p>
                 For stories that you select to be usable for research, we will not use direct quotations from it, 
@@ -179,6 +186,30 @@
                 We have a <a href="https://github.com/alan-turing-institute/AutSPACEs/blob/main/code-of-conduct.md">code of conduct</a> that applies to all online and in person interactions during the project. 
                 We are committed to ensuring that every member of our community is treated with respect. 
             </p>
+
+            <p>
+                Posts that are not in line with our content moderation guidelines will not be made publicly available. 
+                Our moderators will always exclude stories that contain racial slurs and any stories that discriminate or belittle individual people.
+            </p>
+            <p>
+                We do allow publication of some difficult content as we want members of our community to share all their experiences including 
+                the difficult ones. By default content that is moderated as “Amber” are hidden unless you opt-in to seeing them. 
+                You can choose to see stories about:
+            <ul>
+                <li>Abuse (physical, sexual, emotional and verbal)</li>
+                <li>Violence and Assault</li>
+                <li>Drug and/or Alcohol use</li>
+                <li>Mental Health Issues</li>
+                <li>Negative body image</li>
+            </ul>
+            </p>
+            <p>
+                The content warning labels for each publicly available story are added by our content moderators. 
+                Details of that process are available in our <a href="{% url 'main:content_moderation_guidelines' %}">moderator guidelines</a>.
+            </p>
+
+
+
         </div>
 
         <div class="code-of-conduct">

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -189,7 +189,7 @@
 
             <p>
                 Posts that are not in line with our content moderation guidelines will not be made publicly available. 
-                Our moderators will always exclude stories that contain racial slurs and any stories that discriminate or belittle individual people.
+                Our moderators will always exclude stories that contain racial slurs and any stories that discriminate against or belittle individual people.
             </p>
             <p>
                 We do allow publication of some difficult content as we want members of our community to share all their experiences including 

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -140,7 +140,7 @@
 
             <p>
                 Yes. Your email address and username are only stored on the Open Humans system, the AutSPACEs team will not have access to it. 
-                Instead, the AutSPACEs project only receives a randomized identifier that allows us to read & write your experiences into 
+                Instead, the AutSPACEs project only receives a randomised identifier that allows us to read & write your experiences into 
                 Open Humans, without receiving personal identifiable information.
             </p>
             <p>

--- a/server/apps/main/templates/main/participant_information.html
+++ b/server/apps/main/templates/main/participant_information.html
@@ -1,0 +1,219 @@
+{% extends 'main/application.html' %}
+{% load static %}
+{% block title %}AutSPACEs - Participant Information Sheet {% endblock %}
+
+{% block body_attributes%}  {% endblock %}
+
+{% block content %}
+
+<script src="{% static 'js/menu-alignment.js' %}"></script>
+
+<!--Contents-->
+<section id="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div id="menu-container" class="col-lg-3">
+        <div id="content-bar-filler" class="col-lg-3">
+        <!-- Space filler to avoid the main text shifting leftwards -->
+        </div>
+        <div id="content-bar" class="list-group col-lg-3 content-list">
+            <div class="list-group-item content-title fw-bold">Contents</div>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#purpose-of-the-study">Purpose of the study<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#invited">Who is invited to contribute to the project?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#take-part">Do I have to take part?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#what-will-happen">What will happen if I take part in AutSPACEs?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#confidentiality">Will my taking part in this project be kept confidential?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#benefits">What are the possible benefits of taking part?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#disadvantages">What are the possible disadvantages and/or risks in taking part?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#organisers">Who is organising and funding the research?<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#ethics-review">Ethical review of the study<span class="badge badge-pill"></span></a>
+            <a class="list-group-item list-group-item-action  d-flex justify-content-between align-items-center"
+              href="#contact">Contact for further information<span class="badge badge-pill"></span></a>
+        </div>
+      </div>
+
+      <div id="text-container" class="topic-content col-lg-9" 
+           style="padding: 2% 8%">
+           <h2 class="heading-blue">AutSPACEs Participant Information Sheet</h2>
+           <p><b>This page gives a brief overview of the project, including where to find more detailed information, as well 
+            as an outline of what to expect when contributing to AutSPACEs.</b></p>
+
+        <div class="code-of-conduct">
+          <h5 class="heading-blue" id="purpose-of-the-study">Purpose of the study</h5>
+
+            <p>
+                Many autistic people have sensory processing sensitivities and differences when compared to non-autistic people. 
+                These differences can make it difficult to navigate environments that were not built with autistic people in mind. 
+                For example, it can be stressful to take a busy train during rush hour, or to attend an appointment in a brightly lit hospital waiting room. 
+            </p>
+            <p>
+                Every person is different. We want to gather many autistic people’s stories together. 
+                Our goal is to 1) share them with people who have similar experiences, 2) educate neurotypical people on how they can better support 
+                autistic people, and 3) advise people on how they can design and adapt spaces to improve autistic people’s lives. 
+            </p>
+            <p>
+                <b>The purpose of this study is to investigate sensory differences experienced by autistic people by collecting sensory 
+                processing experiences from autistic people in an ethical, participatory way using a citizen science approach.</b>
+            </p>
+            <p>
+                “Citizen-science” is when non-professional scientists directly contribute to scientific research and are involved in the research process. 
+                This could be, for example, by performing tasks, analysing data, or contributing data. 
+            </p>
+            <p>
+            An online “platform” is a way of collecting and sharing data from people. 
+            </p>
+        </div>
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="invited">Who is invited to contribute to the project?</h5>
+
+            <p>
+                The best research about autism is done in close collaboration with autistic people. 
+                Participatory citizen science is a way of doing research that involves many people contributing to the project. 
+                Citizen scientists do not have to be paid academic researchers (in fact most are not) and participatory means 
+                that we will include a large and broad range of people, including non-professional scientists in the direction and design of the work.
+            </p>
+            <p> 
+                We particularly invite autistic people and the carers and relatives of autistic people to contribute to the project. 
+                The eligibility criteria to be part of this study are that participants are over the age of 18 and have capacity to give informed consent.  
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+          <h5 class="heading-blue" id="take-part">Do I have to take part</h5>
+            <p>
+                Taking part is entirely voluntary. You can withdraw at any time without having to give a reason.  
+            </p> 
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="what-will-happen">What will happen if I choose to take part in AutSPACEs?</h5>
+            <p>
+                If you join AutSPACEs you will be able to contribute your own stories around sensory processing experiences in text form, 
+                alongside recommendations of what would have made that experience better. 
+                Additionally, we ask you to fill in a small profile with demographic information (age, gender, whether you identify as autistic). 
+            </p>
+            <p>
+                Entering any of these data is optional and participation more broadly is voluntary. 
+                For each story or experience you share you can choose whether you want to allow researchers to use this story for their 
+                research and/or if you want to make it publicly accessible for others to read as well. 
+            </p>
+            <p>
+                If you choose to share your story for research, your story will be part of a research dataset alongside 
+                other people’s experiences, and our research team at The Alan Turing Institute will be able to use that experience 
+                to learn about shared sensory processing challenges.
+            </p>
+            <p>
+                If you choose to make your experience public, your experience will first be checked over by a moderator 
+                to make sure it follows our content moderation guidelines. 
+                If you opt-in to receive notifications, we will let you know when a moderator has decided about your experience. 
+                If your story follows our content moderation guidelines, it will be published anonymously on this website. 
+                Anyone will be able to view your story, but your name will be kept private. 
+                You can make this choice by checking the box ‘share online with everyone’.
+            </p>
+            <p>
+                Both sharing for research and making stories are optional, you can also choose neither, 
+                in which case you can personally see your stories, but they won’t be publicly listed or used for research. 
+            </p>
+            <p>
+                For each of your stories you can always change your mind and edit/rewrite it, 
+                delete it or change your sharing settings at any time.
+            </p>
+            <p>
+                All your data and information will be handled according to 
+                The Alan Turing Institute Information Policy that you can read here 
+                <a href="https://www.turing.ac.uk/data-protection-policy">https://www.turing.ac.uk/data-protection-policy </a>
+            </p>
+    
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="confidentiality">Will my taking part in this project be kept confidential?</h5>
+
+            <p>
+                Yes. Your email address and username are only stored on the Open Humans system, the AutSPACEs team will not have access to it. 
+                Instead, the AutSPACEs project only receives a randomized identifier that allows us to read & write your experiences into 
+                Open Humans, without receiving personal identifiable information.
+            </p>
+            <p>
+                If you decide to make a story publicly accessible, a moderator from our research team will review it in accordance to our 
+                content moderation guidelines, to amongst other things avoid that it contains personal identifiable information.
+            </p>
+            <p>
+                For stories that you select to be usable for research, we will not use direct quotations from it, 
+                unless the stories are also publicly shared. For non-public stories that are consented for research use, 
+                we will use the anonymous contact feature of AutSPACEs to request your individual consent with the possibility 
+                to redact personal information before using any quotes. 
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="benefits">What are the possible benefits of taking part?</h5>
+            <p>
+                By taking part in AutSPACEs, you will be able to share your sensory processing experiences both for research and publicly. 
+                Writing up these stories can be a way to process past experiences to personally learn from them.
+            </p>
+            <p>
+                Regardless of whether you are taking part in AutSPACEs by contributing stories, 
+                you will also be able to read publicly shared stories, which has the potential to be beneficial by 
+                learning from other contributors’ adaptive techniques. 
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="disadvantages">What are the possible disadvantages and/or risks in taking part?</h5>
+            <p>
+                Our goal is to learn from autistic people’s experiences of challenges they have navigating environments that were not 
+                designed by or for autistic people. You may find it stressful or upsetting to remember and share these difficult experiences 
+                although this is not a necessary required. <b>If you do not wish to participate in any parts of AutSPACEs, you do not have to. </b>
+            </p>
+            <p>
+                We have a <a href="https://github.com/alan-turing-institute/AutSPACEs/blob/main/code-of-conduct.md">code of conduct</a> that applies to all online and in person interactions during the project. 
+                We are committed to ensuring that every member of our community is treated with respect. 
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="organising">Who is organising and funding the research?</h5>
+            <p>
+                The study is funded by Autistica and The Alan Turing Institute. The lead investigators are Dr. Kirstie Whitaker and Dr. Bastian Greshake Tzovaras. 
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="ethics-review">Ethical review of the study</h5>
+            <p>
+                The project has been reviewed by The Alan Turing Institute’s Ethics Committee. 
+                You can <a href="https://github.com/alan-turing-institute/AutisticaCitizenScience/tree/master/project-management/ethics-applications">find our ethics documentation on GitHub</a>.
+            </p>
+        </div>
+
+        <div class="code-of-conduct">
+            <h5 class="heading-blue" id="contact">Contact for further information</h5>
+            <p>
+                You can contact Georgia Aitkenhead by email at gaitkenhead@turing.ac.uk for any further information.
+            </p>
+            <p>
+                If you feel that your query has not been properly addressed you may contact the project lead investigators: 
+                Dr. Kirstie Whitaker at kwhitaker@turing.ac.uk  or Dr. Bastian Greshake Tzovaras at bgreshaketzovaras@turing.ac.uk.
+            </p>
+            <p>
+                If you have any concerns about how your data and information has been handled you can also get in contact with our Data Protection team at dataprotection@turing.ac.uk.  
+            </p>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+</section>
+
+{%endblock%}

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -31,7 +31,7 @@
             <p>AutSPACEs allows users to share stories publicly with other users as well as privately with researchers.
               In order
               for the platform to be a respectful and welcoming place for autistic people and other members of the
-              community, everyone sharing a story publicly will be required to follow this code of conduct. Before they
+              community, everyone sharing a story publicly will be required to follow our content moderation guidelines. Before they
               are
               published all stories will be reviewed by a moderator who will use this document as guidance when making
               decisions as to whether a post can be approved or not.</p>
@@ -242,7 +242,7 @@
           <div id="reasons">
             <div class="d-flex flex-row mb-3 reason-row">
               <div class="p-2 col col-lg-8 border text">{{ obj.text }}</div>
-              <div class="p-2 col col-lg-4 border reason"><a href="/main/code_of_conduct/#{{ obj.href }}">{{ obj.reason }}</a></div>
+              <div class="p-2 col col-lg-4 border reason"><a href="/main/content_moderation_guidelines/#{{ obj.href }}">{{ obj.reason }}</a></div>
             </div>
           </div>
       {% endfor %}

--- a/server/apps/main/tests/test_views.py
+++ b/server/apps/main/tests/test_views.py
@@ -170,9 +170,9 @@ class Views(TestCase):
         response = c.get("/main/help/")
         assert response.status_code == 200
 
-    def test_code_of_conduct(self):
+    def test_content_moderation_guidelines(self):
         c = Client()
-        response = c.get("/main/code_of_conduct/")
+        response = c.get("/main/content_moderation_guidelines/")
         assert response.status_code == 200
 
     def test_registration(self):

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -29,7 +29,8 @@ urlpatterns = [
     path("about_us/", views.about_us, name="about_us"),
     path("what_autism_is/", views.what_autism_is, name="what_autism_is"),
     path("help/", views.help, name="help"),
-    path("code_of_conduct/", views.code_of_conduct, name="code_of_conduct"),
+    path("content_moderation_guidelines/", views.content_moderation_guidelines, name="content_moderation_guidelines"),
+    path("participant_information/", views.participant_information, name="participant_information"),
     path("registration/", views.registration, name="registration"),
     path("single_story/<uuid>/",views.single_story,name="single_story")
 ]

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -85,9 +85,11 @@ def help(request):
     return render(request, "main/help.html")
 
 
-def code_of_conduct(request):
-    return render(request, "main/code_of_conduct.html")
+def content_moderation_guidelines(request):
+    return render(request, "main/content_moderation_guidelines.html")
 
+def participant_information(request):
+    return render(request, "main/participant_information.html")
 
 def edit_experience(request):
     return render(request, "main/share_experiences.html")

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -660,7 +660,7 @@ arrowhead {
   margin-bottom: 3%;
 }
 
-/* CODE OF CONDUCT */
+/* CODE OF CONDUCT / CONTENT MODERATION GUIDELINES */
 
 .word-red {
   color: #cc0000;

--- a/static/js/moderation-replies.js
+++ b/static/js/moderation-replies.js
@@ -110,7 +110,7 @@ $(function() {
     for (var index = 0; index < reasons.length; index++) {
       let reasonrow = $($("#template-reasons").prop('content')).find('.reason-row').clone()
       reasonrow.find(".reason").text(reasons[index].reason)
-      reasonrow.find(".reason").attr("href", "/main/code_of_conduct/#" + reasons[index].href)
+      reasonrow.find(".reason").attr("href", "/main/content_moderation_guidelines/#" + reasons[index].href)
       reasonrow.find(".text").text(reasons[index].text)
       reasonrow.find(".remove").on("click", {index: index}, function(event) {
         event.preventDefault()


### PR DESCRIPTION
This PR adds the Participant Information Sheet, which we have also submitted as a PDF version for the ethics submission as a proper page to the AutSPACEs platform. 

As part of this work, I have also renamed and clarified the two types of "Code of Conduct" we have so far used interchangeably: 

1. The "actual" code of conduct ([on GH here](https://github.com/alan-turing-institute/AutSPACEs/blob/main/code-of-conduct.md)), which covers the interactions in Slack, Zoom, etc. 
2. The "content moderation guidelines" that moderators use to evaluate publicly shared stories and moderate them. 

So far the latter was also called "code of conduct", leading to confusion as there were two different documents with the same name. For clarity (and in line with the wording we've used for the moderation paper) I renamed those "content moderation guidelines" instead. 

Beyond the automated tests I've also manually tested the moderation functions to ensure that the still all work as expected :)