### PR TITLE
Indicate that trigger-toggles worked

### DIFF
--- a/server/apps/main/templates/main/experiences_page.html
+++ b/server/apps/main/templates/main/experiences_page.html
@@ -8,6 +8,16 @@
 
 {% block content %}
 
+<div class="modal fade" id="spinnerModal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered justify-content-center">
+      <div class="text-center">
+        <div class="spinner-border" role="status">
+          <span class="visually-hidden">Refreshing...</span>
+        </div>
+    </div>
+  </div>
+</div>
+
 
 <div class="experience-intro">
   <div class="container">

--- a/static/js/shared-stories-filtering.js
+++ b/static/js/shared-stories-filtering.js
@@ -18,8 +18,7 @@ $(all_check).change(function(){
             document.getElementById(trigger_array[i]).checked = false
         }
     }
-
-    $("#search-form").submit()
+    modal();
 })
 
 $("#single_trigger_warnings :checkbox").change(function(){
@@ -36,8 +35,7 @@ $("#single_trigger_warnings :checkbox").change(function(){
     } else {
         document.getElementById("all-checkbox").checked = true
     }
-
-    $("#search-form").submit()
+    modal();
 
 });
 
@@ -49,6 +47,13 @@ document.addEventListener("DOMContentLoaded", function(event) {
 window.onbeforeunload = function(e) {
     localStorage.setItem('scrollpos', window.scrollY);
 };
-
-
   
+function modal(){
+    $('.modal').modal('show');
+    setTimeout(function () {
+        $("#search-form").submit();
+        //$('.modal').modal('hide');
+    }, 250);
+}
+
+ document.getElementById("modalbutton").addEventListener("click", modal);


### PR DESCRIPTION
This fixes #606, by including a modal overlay of a "spinner" to indicate that the updated results are loaded. 

Technically, this is a bit smoke & mirrors, as it's completely unrelated to the actual loading, instead there's a quarter second period in which the overlay is shown before then reloading the website with the new results. 

While definitely not an elegant solution, I think for now this is a pragmatic approach, as the more dynamic implementation would mean a quite big chunk of work to refactor how the loading of the results happens!