### PR TITLE
adds rss/atom feeds for public experiences

### DIFF
--- a/server/apps/main/feeds.py
+++ b/server/apps/main/feeds.py
@@ -30,7 +30,7 @@ class PublicExperienceFeed(Feed):
 		return "AutSPACEs public experiences"
 
 	def link(self, obj):
-		return "https://example.com"
+		return reverse("main:public_experiences")
 
 	def description(self, obj):
 		joined_triggers = ", ".join(obj)
@@ -51,7 +51,7 @@ class PublicExperienceFeed(Feed):
 	def items(self, obj):
 		experiences = PublicExperience.objects.filter(moderation_status="approved")
 		experiences = expand_filter(experiences, obj)
-		experiences = experiences.order_by("-created_at")[:5]
+		experiences = experiences.order_by("-created_at")[:10]
 		return experiences
 
 class PublicExperienceAtomFeed(PublicExperienceFeed):

--- a/server/apps/main/feeds.py
+++ b/server/apps/main/feeds.py
@@ -1,0 +1,59 @@
+from .models import PublicExperience
+from django.contrib.syndication.views import Feed
+from django.urls import reverse
+from server.apps.main.helpers import extract_triggers_to_show, expand_filter
+from django.utils.feedgenerator import Atom1Feed
+
+class PublicExperienceFeed(Feed):
+	description_template = "main/feed.html"
+
+	def get_object(self, request):
+		# check if 'all triggers' is in keys
+		all_triggers = request.GET.get("all_triggers", False)
+		# set all trigger labels if set
+		if all_triggers:
+			allowed_triggers = {
+	            "abuse",
+	            "violence",
+	            "drug",
+	            "mentalhealth",
+	            "negbody",
+	            "other",
+        	}
+		else:
+        	# Check the allowed triggers
+			allowed_triggers = set(request.GET.keys())
+		triggers_to_show = extract_triggers_to_show(allowed_triggers)
+		return triggers_to_show
+
+	def title(self, obj):
+		return "AutSPACEs public experiences"
+
+	def link(self, obj):
+		return "https://example.com"
+
+	def description(self, obj):
+		joined_triggers = ", ".join(obj)
+		if joined_triggers:
+			return "This feed includes potentially triggering stories related to %s" % joined_triggers
+		else:
+			return "No triggering content is included in this feed"
+
+	def item_link(self, item):
+		return reverse('main:single_story', args=[item.experience_id])
+	
+	def item_title(self, item):
+		return item.title_text
+
+	def item_pubdate(self, item):
+		return item.created_at
+
+	def items(self, obj):
+		experiences = PublicExperience.objects.filter(moderation_status="approved")
+		experiences = expand_filter(experiences, obj)
+		experiences = experiences.order_by("-created_at")[:5]
+		return experiences
+
+class PublicExperienceAtomFeed(PublicExperienceFeed):
+	feed_type = Atom1Feed
+	subtitle = PublicExperienceFeed.description

--- a/server/apps/main/templates/main/application.html
+++ b/server/apps/main/templates/main/application.html
@@ -26,6 +26,12 @@
     <link href="{% static '/css/main.css' %}" rel="stylesheet">
     {%block page_css%} {% endblock %}
 
+    <!-- RSS links where appropriate -->
+    {% if rss_link %}
+    <link rel="alternate" type="application/rss+xml" href="{{rss_link}}">
+    <link rel="alternate" type="application/atom+xml" href="{{atom_link}}">
+    {% endif %}
+
   </head>
 
   <body {% block body_attributes%} {% endblock %}>

--- a/server/apps/main/templates/main/experiences_page.html
+++ b/server/apps/main/templates/main/experiences_page.html
@@ -135,8 +135,9 @@
         </div>
       </div>
       </div>
-
     </form>
+    <div class="form-text">
+      <a href="{{atom_link}}" <i class="bi bi-rss"></i> You can also subscribe to this page as a feed</a>. The current trigger options will be preserved.</div>
   </div>
   {% if searched %}
     <div class="container-fluid story-text">
@@ -144,8 +145,6 @@
     </div>
   {% endif %}
 </section>
-
-
 <section id="stories-post">
   <div class="container-fluid story-text">
     {% for experience in experiences %}

--- a/server/apps/main/templates/main/experiences_page.html
+++ b/server/apps/main/templates/main/experiences_page.html
@@ -136,8 +136,6 @@
       </div>
       </div>
     </form>
-    <div class="form-text">
-      <a href="{{atom_link}}" <i class="bi bi-rss"></i> You can also subscribe to this page as a feed</a>. The current trigger options will be preserved.</div>
   </div>
   {% if searched %}
     <div class="container-fluid story-text">
@@ -228,6 +226,8 @@
     <!-- Add Pagination -->
     {% include 'main/pagination.html' with stories=experiences page_query_param='page' %}
     {% endif %}
+    <div class="form-text">
+      <a href="{{atom_link}}" <i class="bi bi-rss"></i> You can also subscribe to this page as a feed</a>. The current trigger options will be preserved.</div>
   </div>
 </section>
 

--- a/server/apps/main/templates/main/feed.html
+++ b/server/apps/main/templates/main/feed.html
@@ -1,10 +1,10 @@
 
-<h2>Experience</h2>
+<h2>The experience</h2>
 <p>
 {{ obj.experience_text }}
 </p>
 
-<h2>Difference</h2>
+<h2>What would make a difference</h2>
 <p>
     {{ obj.difference_text }}
 </p>

--- a/server/apps/main/templates/main/feed.html
+++ b/server/apps/main/templates/main/feed.html
@@ -1,0 +1,10 @@
+
+<h2>Experience</h2>
+<p>
+{{ obj.experience_text }}
+</p>
+
+<h2>Difference</h2>
+<p>
+    {{ obj.difference_text }}
+</p>

--- a/server/apps/main/tests/test_views.py
+++ b/server/apps/main/tests/test_views.py
@@ -804,3 +804,21 @@ class Views(TestCase):
                     assert len(stories) == min(num_items_per_page, n_stories)
                     # check story numbering
                     assert stories[0]['number'] == num_items_per_page + 1  # first story on page 1 is continuation of page 1
+
+
+
+    def test_feeds(self):
+        c = Client()
+        c.force_login(self.user_a)
+        response = c.get("/main/public_experiences/rss.xml")
+        assert response.status_code == 200
+        self.assertTemplateUsed(response, "main/feed.html")
+        # Check that there is only one story visible - the one with no triggering labels
+        self.assertContains(response,"No triggering content is included in this feed")
+        self.assertContains(response,"<item>", count=1)
+        
+        # If you allow the abuse tag there should be 2 stories one with no tags one with the abuse tag
+        search_response_abuse = c.get("/main/public_experiences/rss.xml?abuse=True")
+        print(search_response_abuse.content)
+        self.assertNotContains(search_response_abuse,"No triggering content is included in this feed")
+        self.assertContains(search_response_abuse,"<item>", count=2)

--- a/server/apps/main/tests/test_views.py
+++ b/server/apps/main/tests/test_views.py
@@ -819,6 +819,11 @@ class Views(TestCase):
         
         # If you allow the abuse tag there should be 2 stories one with no tags one with the abuse tag
         search_response_abuse = c.get("/main/public_experiences/rss.xml?abuse=True")
-        print(search_response_abuse.content)
         self.assertNotContains(search_response_abuse,"No triggering content is included in this feed")
         self.assertContains(search_response_abuse,"<item>", count=2)
+
+
+        search_response_t = c.get("/main/public_experiences/rss.xml?all_triggers=True")
+        self.assertContains(search_response_t,"<item>", count=2)
+
+        

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -34,6 +34,6 @@ urlpatterns = [
     path("registration/", views.registration, name="registration"),
     path("single_story/<uuid>/",views.single_story,name="single_story"),
     path("success_confirm/", views.success_confirm, name="success_confirm"),
-    path("public_experiences/rss/", feeds.PublicExperienceFeed(), name='rss_feed'),
-    path("public_experiences/atom/", feeds.PublicExperienceAtomFeed(), name='atom_feed'),
+    path("public_experiences/rss.xml", feeds.PublicExperienceFeed(), name='rss_feed'),
+    path("public_experiences/atom.xml", feeds.PublicExperienceAtomFeed(), name='atom_feed'),
 ]

--- a/server/apps/main/urls.py
+++ b/server/apps/main/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path, re_path
 from server.apps.main import views
+from server.apps.main import feeds
 
 app_name = "main"
 
@@ -33,4 +34,6 @@ urlpatterns = [
     path("registration/", views.registration, name="registration"),
     path("single_story/<uuid>/",views.single_story,name="single_story"),
     path("success_confirm/", views.success_confirm, name="success_confirm"),
+    path("public_experiences/rss/", feeds.PublicExperienceFeed(), name='rss_feed'),
+    path("public_experiences/atom/", feeds.PublicExperienceAtomFeed(), name='atom_feed'),
 ]

--- a/server/apps/main/views.py
+++ b/server/apps/main/views.py
@@ -410,7 +410,10 @@ def list_public_experiences(request):
 
     exp_context = {"experiences": page_experiences}
 
-    context = {**tts, **exp_context, **search_context}
+    rss_link = reverse("main:rss_feed") + "?" +  request.GET.urlencode()
+    atom_link = rss_link = reverse("main:atom_feed") + "?" +  request.GET.urlencode()
+
+    context = {'rss_link': rss_link, 'atom_link': atom_link, **tts, **exp_context, **search_context}
 
     # Standard page showing all moderated stories
     return render(request, "main/experiences_page.html", context=context)


### PR DESCRIPTION
Closes #610 

This PR adds both an Atom & RSS feed on the public experiences page, properly linked behind the scenes in the `head` of the website as appropriate to facilitate automatic discovery of it. 

It also includes a link to the feed on that page in order to highlight this flag beyond automated discovery. Furthermore, the feed links automatically mirror the current view including the trigger inclusion choices, so that people can subscribe to a feed that includes only those topics they are comfortable reading about. 