### PR TITLE
add contextual back button

### DIFF
--- a/server/apps/main/templates/main/single_story.html
+++ b/server/apps/main/templates/main/single_story.html
@@ -61,8 +61,22 @@
     <h3>What could have made the experience better?</h3>
     <p><i>{% firstof experience.difference_text "No Difference Text Given" %}</i></p>
     </div>
+    
+    <a
+    class="btn btn-primary"
+    {% if request.META.HTTP_REFERER %}
+    href="{{ request.META.HTTP_REFERER }}"
+    {% else %}
+    href="{% url 'main:public_experiences' %}"
+    {% endif %}
+    >
+    Back to list of stories
+    </a>
 
   </div>
+
+
+
 
 
 </section>


### PR DESCRIPTION
To move back from a single story to "correct" page of public experiences, with triggers etc preserved, closes #540 540

In the end it didn't require messing around with custom sessions, as Django helpfully offers the `META.HTTP_REFERER` entry in the `request` itself!