### PR TITLE
Fix dark buttons & "other" trigger moderation bug

### DIFF
--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -88,7 +88,7 @@ def process_trigger_warnings(form):
     trigger_warning_dict = {
         k: form.cleaned_data[k]
         for k in form.data.keys()
-        if k not in ["csrfmiddlewaretoken", "research"]
+        if k not in ["csrfmiddlewaretoken", "research", "other_trigger"]
     }
 
     # Set all others as False

--- a/server/apps/main/templates/main/moderate_experience.html
+++ b/server/apps/main/templates/main/moderate_experience.html
@@ -310,7 +310,7 @@
         </template>
 
         <div class='form-group'>
-          <input type="submit" class="btn btn-outline-dark btn-lg float-end" id="submitBtn" value="Submit">
+          <input type="submit" class="btn btn-primary btn-lg float-end" id="submitBtn" value="Submit">
         </div>
       </form>
     </div>

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -271,7 +271,7 @@
     {% else %}
         <div class='form-group'>
           <!-- Add an id and data attributes to the submit button -->
-            <button type="button" class="btn btn-outline-dark btn-lg float-end" id="submitBtn"
+            <button type="button" class="btn btn-primary btn-lg float-end" id="submitBtn"
             data-uuid="{{ uuid }}" data-moderation-status="{{ moderation_status }}">Submit</button>
         </div>
       </form>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -752,7 +752,7 @@ arrowhead {
 
 .collapsablecell a {
   text-decoration: none;
-  color: #000;
+  color: var(--bs-table-color-state);
 }
 
 .collapsablecell p.collapse:not(.show) {


### PR DESCRIPTION
This PR fixes #661, which @GeorgiaHCA & I uncovered in the second round of (ongoing) user testing. 

While doing this I found two more bugs that this PR addresses: 

1. The text in the "moderation history" table in the moderate view was black & black as well when using dark mode
2. The moderation form crashed when using the "other trigger labels" field, due to how the checkbox/trigger labels were processed. 