### PR TITLE
fix self-id label issue for public experiences

### DIFF
--- a/server/apps/main/templates/main/experiences_page.html
+++ b/server/apps/main/templates/main/experiences_page.html
@@ -182,7 +182,13 @@
             <h5 class="card-title story-header">{{ experience.number }}. {% firstof experience.title_text "no title given" %}</h5>
               <p class="card-text">{% firstof experience.experience_text|truncatechars:100 "no experience text given" %}</p>
               {% if experience.first_hand_authorship %}
-                <em>Autistic individual</em>
+                {% if experience.open_humans_member.user.userprofile.autistic_identification == 'yes' %}
+                  <em>Autistic individual</em>
+                {% elif experience.open_humans_member.user.userprofile.autistic_identification == 'no' %}
+                  <em>Non-autistic individual</em>
+                {% else %}
+                  <em>User has not answered if they identify as autistic</em>
+                {% endif %}
               {% else %}
               <em>{% firstof experience.authorship_relation "AutSPACEs Contributor" %}</em>
               {% endif %}

--- a/server/settings/environments/development.py
+++ b/server/settings/environments/development.py
@@ -121,7 +121,8 @@ NPLUSONE_LOGGER = logging.getLogger('django')
 NPLUSONE_LOG_LEVEL = logging.WARN
 NPLUSONE_WHITELIST = [
     {'model': 'admin.*'},
-    {'label': 'n_plus_one', 'model': 'users.UserProfile'}
+    {'label': 'n_plus_one', 'model': 'users.UserProfile'},
+    {'label': 'n_plus_one', 'model': 'main.PublicExperience'}
 ]
 
 


### PR DESCRIPTION
closes #659 

Now the front-end will display whether a person filled out the autism self-id question (see screenshots below). 

A question that remains and which is non-technical is whether we even want to release public experiences that aren't either on someone elses behalf or written by someone id'ing as autistic? 

![Screenshot 2024-04-12 at 15 21 45](https://github.com/alan-turing-institute/AutSPACEs/assets/674899/40cf166d-dd68-4d93-b877-fe966ad80d0d)
![Screenshot 2024-04-12 at 15 22 54](https://github.com/alan-turing-institute/AutSPACEs/assets/674899/82d78599-0385-4bdd-acbd-4bad0e1ec76c)
