### PR TITLE
[WIP] lower visual noise

### DIFF
--- a/server/apps/main/forms.py
+++ b/server/apps/main/forms.py
@@ -7,14 +7,15 @@ class ShareExperienceForm(forms.Form):
 
 
     experience_text = forms.CharField(label='Please share your experience', strip=True,
-
-                                 widget=forms.Textarea(attrs={'placeholder':'Write your experience here, you can take as much or little space as you need.',
-                                                              'rows':'4',
-                                                              'class':'form-control'}))
+                                help_text='Write your experience here, you can take as much or little space as you need.',
+                                widget=forms.Textarea(attrs={'placeholder':'Please share your story.',
+                                                             'rows':'4',
+                                                             'class':'form-control'}))
     experience_text.group = 1
     difference_text = forms.CharField(label='What could have made your experience better?',
-                                     strip=True,
-                                     widget=forms.Textarea(attrs={'placeholder':'Do you have anything that you would want to have changed to make it better? Or do you have any tips for others who may experience the same thing?',
+                                      strip=True,
+                                      help_text='Do you have anything that you would want to have changed to make it better? Or do you have any tips for others who may experience the same thing?',
+                                      widget=forms.Textarea(attrs={'placeholder':'What could have been different?',
                                                               'rows':'4',
                                                               'class':'form-control'}))
     difference_text.group = 1

--- a/server/apps/main/templates/main/home.html
+++ b/server/apps/main/templates/main/home.html
@@ -1,6 +1,6 @@
 {% extends 'main/application.html' %}
 {% load static %}
-{% block title %}AutSPACEs - What is Autism? {% endblock %}
+{% block title %}AutSPACEs{% endblock %}
 
 {% block body_attributes%} data-bs-spy="scroll" data-target="#content-bar" {% endblock %}
 

--- a/server/apps/main/templates/main/partials/footer.html
+++ b/server/apps/main/templates/main/partials/footer.html
@@ -2,14 +2,9 @@
 
   <div class="row">
     <div class="col-lg-3 footer-column">
-      <a class="clear-hover" href="https://www.autistica.org.uk/">
-        <img class="footer-image" src="{% static "/images/autistica.png" %}" width="65" height="40" alt="Autistica Logo" />
-      </a>
-      <a class="clear-hover" href="https://www.turing.ac.uk/">
-        <img class="footer-image" src="{% static "/images/alanturing.png" %}" width="75" height="40" alt="Alan Turing Institute Logo" />
-      </a>
+      <a href="https://www.autistica.org.uk/"><img class="footer-image" src="{% static '/images/autistica.png' %}" width="65" height="40" alt="Autistica Logo" /></a>
+      <a href="https://www.turing.ac.uk/"><img class="footer-image" src="{% static '/images/alanturing.png' %}" width="75" height="40" alt="Alan Turing Institute Logo" /></a>
       <p class="footer-text">&copy; Copyright 2023 AutSPACEs</p>
-      <p class="footer-text"><a href="https://twitter.com/AutSpaces">@AutSpaces</a> on Twitter</p>
     </div>
     <div class="col-lg-3 footer-text">
       <h5>Supported by:</h5>

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -169,6 +169,7 @@
         {% for field in group.list %}
         <div class="form-group">
           <h3><label for="{{ field.id_for_label }}">{{ field.label }}</label></h3>
+          <h5>{{ field.help_text }}</h5>
           {{ field }}
         </div>
         {% endfor %}
@@ -218,14 +219,14 @@
                 <label for="{{ field.id_for_label }}">{{ field.label }}</label>
               {% endif %}
               {% if field.help_text %}
-               <div id="help_{{field.auto_id}}" class="form-text">
+               <div id="help_{{field.auto_id}}" class="form-text form-text-color">
                  {{field.help_text|safe}}</div>
               {% endif %}
             </div>
 
           {% endfor %}
           {% if group.grouper == 3 %}
-          <div class="form-text">
+          <div class="form-text form-text-color">
             If neither of these boxes are checked, the story is only visible to yourself. In this case, the story will not be used for research and not moderated. 
             You can always change these settings from the <i>My Stories</i> page.
           </div>

--- a/server/apps/users/forms.py
+++ b/server/apps/users/forms.py
@@ -83,8 +83,12 @@ class UserProfileForm(forms.Form):
 
     description = forms.CharField(label="What else would you like researchers (or readers) to know about yourself?",
                                  max_length=2048, strip=True, required=False,
-                                 help_text="You can provide any additional context about yourself here that you deem relevant to understanding your perspective and experiences. The AutSPACEs team will potential use your information to refine the structured demographic questions above. You can also make this information publicly accessible &mdash; which will be linked to your public experiences.",
-                                 widget=forms.Textarea(attrs={"placeholder":"Potential things you could talk about here include your ethnicity, whether you grew up/are living in a rural or urban environment, your educational background or really anything else that comes to your mind.",
+                                 help_text="""You can provide any additional context about yourself here that you deem 
+                                 relevant to understanding your perspective and experiences. This could be your ethnicity, 
+                                 where you grew up, your educational background, or when and how you (self-)diagnosed.
+                                 The AutSPACEs team might use this information to refine the structured demographic questions above. 
+                                 You can also make this information publicly accessible &mdash; which might be linked to your public experiences in the future.""",
+                                 widget=forms.Textarea(attrs={"placeholder":"Optionally share more about yourself",
                                                               "rows":"4",
                                                               "class":"form-control",
                                                               "aria-describedby": "help_id_description"}))

--- a/server/apps/users/templates/users/delete.html
+++ b/server/apps/users/templates/users/delete.html
@@ -32,7 +32,7 @@
         {% endfor %}
       </div>
       <div class="form-group">
-        <button type="submit" class="btn btn-primary" id="submitForm">Delete account</button>
+        <button type="submit" class="btn btn-danger" id="submitForm">Delete account</button>
         <a role="button" class="btn btn-secondary ml-5" id="cancelForm" href="{% url 'users:profile' %}">Cancel</a>
       </div>
     </form>

--- a/server/apps/users/templates/users/profile.html
+++ b/server/apps/users/templates/users/profile.html
@@ -66,7 +66,7 @@
 
         {% if group.grouper == 2 %}
         <p>
-          <small id="help_{{field.auto_id}}" class="form-text text-muted">
+          <small id="help_{{field.auto_id}}" class="form-text form-text-color">
             You can modify these defaults at any time. You can also override the defaults from the <i>View Stories</i> page.
           </small>
         </p>
@@ -84,7 +84,7 @@
               <p/><label for="{{ field.auto_id }}">{{ field.label }}</label>
               {{ field }}
               {% if field.help_text %}
-              <small id="help_{{field.auto_id}}" class="form-text text-muted">
+              <small id="help_{{field.auto_id}}" class="form-text form-text-color">
                 {{field.help_text|safe}}
               </small>
               {% endif %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -374,6 +374,9 @@ body {
   color: #fff;
  }
 
+ .form-text-color {
+  color: var(--bs-body-color);
+ }
 
  /*Responsive Design*/
  @media (max-width: 992px) {
@@ -507,7 +510,7 @@ body {
 }
 
 .story-header {
-  color: #F1806F;
+  color: #1BB5AF;
   font-size: 2rem;
   line-height: 2;
   font-weight: bold;
@@ -633,7 +636,7 @@ body {
 /* REGISTRATION PAGE */
 #registration-intro {
   padding: 3% 5%;
-  background-color: #F1806F;
+  background-color: #1BB5AF;
   color: #fff;
 }
 
@@ -648,12 +651,12 @@ body {
 connection {
   border: 16px solid;
   border-radius: 7em;
-  color: #1BB5AF;
+  color: #F9BB33;
 }
 
 arrowhead {
-  border-top: solid 8px #1BB5AF;
-  border-right: solid 8px #1BB5AF;
+  border-top: solid 8px #F9BB33;
+  border-right: solid 8px #F9BB33;
   border-bottom: solid 8px transparent;
   border-left: solid 8px transparent;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -61,7 +61,8 @@ body {
 /* FOOTER */
 
 #footer {
-  background: #F2F2F2;
+  /* background: var(--bs-tertiary-bg);*/
+  background: #F2F2F2; 
   padding: 2% 5%;
   color:#000;
   position: relative;
@@ -78,6 +79,10 @@ body {
 .footer-text {
   text-align: left;
   padding-right: 2%;
+}
+
+.footer-text a {
+  color: var(--bs-blue);
 }
 
 .footer-text p {
@@ -214,7 +219,7 @@ body {
  }
 
  .experience-content {
-   color: #8f8f8f;
+   color: var(--bs-body-color);
    line-height: 1.5;
    font-size: 20px;
  }
@@ -430,7 +435,7 @@ body {
 }
 
 .submitted {
-  background-color: #F1806F !important;
+  background-color: #F9BB33 !important;
 }
 
 .messages {

--- a/static/js/shared-stories-filtering.js
+++ b/static/js/shared-stories-filtering.js
@@ -53,7 +53,7 @@ function modal(){
     setTimeout(function () {
         $("#search-form").submit();
         //$('.modal').modal('hide');
-    }, 250);
+    }, 450);
 }
 
  document.getElementById("modalbutton").addEventListener("click", modal);


### PR DESCRIPTION
Will close (parts of) #667. 

- [x] Move placeholder texts into help texts in forms (i.e. avoid it becoming invisible once people start typing)
- [x] Increase contrast of help-texts (from light-grey to proper main body colour)
- [x] Remove bright red colour from `register` page
- [x] Remove bright red from other pages
- [x] checked that dark mode text is readable across more pages/sections (e.g. footer, 'my stories')