### PR TITLE
Mark 1st time contributions

### DIFF
--- a/server/apps/main/helpers.py
+++ b/server/apps/main/helpers.py
@@ -423,6 +423,7 @@ def moderate_page(request, tabbed_stories):
         paginator = Paginator(stories, items_per_page)
         stories = paginate_stories(request, paginator, status)
         stories = number_stories(stories, items_per_page)
+        stories = number_stories_by_author(stories)
         tabbed_stories[status] = stories
 
     context={
@@ -564,6 +565,20 @@ def number_stories(stories, items_per_page):
             story.number = i + 1
         elif isinstance(story, dict):
             story["number"] = i + 1
+        else:
+            raise TypeError(f'Unexpected type for story: {type(story)}')
+    return stories
+
+def number_stories_by_author(stories):
+    """
+    Adds a field to each story if it's that person's first story
+
+    """
+    # iterate over all stories in that batch
+    for story in stories:
+        if isinstance(story, PublicExperience):
+            number_stories = story.open_humans_member.publicexperience_set.all().count()
+            story.author_stories = number_stories
         else:
             raise TypeError(f'Unexpected type for story: {type(story)}')
     return stories

--- a/server/apps/main/templates/main/moderation_table.html
+++ b/server/apps/main/templates/main/moderation_table.html
@@ -19,7 +19,14 @@
       <tr>
         <th scope="row">{{ file.number }}</th>
 
-        <td>{% firstof file.title_text "notitle" %}</td>
+        <td>
+          {% firstof file.title_text "notitle" %}
+          {% if file.author_stories == 1 %}
+          <span class="badge text-bg-primary">
+            Contributor's first story
+            </span>
+            {% endif %}
+        </td>
         <td>
         {% if file.other %}
           <span class="badge text-bg-warning float-end"

--- a/server/apps/main/templates/main/share_experiences.html
+++ b/server/apps/main/templates/main/share_experiences.html
@@ -286,9 +286,6 @@
       <div class="modal-content">
         <div class="modal-header">
           <h5 class="modal-title" id="submitModalLabel">Confirmation</h5>
-          <button type="button" class="close" data-bs-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
         </div>
         <div class="modal-body">
           Submitting your edited story will send it for moderation again. Do you want to proceed?


### PR DESCRIPTION
This closes #511 (for now at least) by adding in a small label that highlights on the moderation panel when a given story is someone's first contribution (see screenshot). 


![Screenshot 2024-05-08 at 11 36 51](https://github.com/alan-turing-institute/AutSPACEs/assets/674899/20411039-2f89-4eab-9be2-0843a8d0d7ce)
